### PR TITLE
Add restart UX + Caps Lock indicator across typing flows

### DIFF
--- a/src/routes/Home.css
+++ b/src/routes/Home.css
@@ -594,20 +594,42 @@
 }
 
 .practice-body {
+  position: relative;
   display: flex;
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  padding: var(--space-6) var(--page-padding);
+  padding: calc(var(--space-6) + var(--space-7)) var(--page-padding) var(--space-6);
   gap: var(--space-6);
   overflow: hidden;
 }
 
 @media (max-width: 600px) {
   .practice-body {
-    padding: var(--space-4) var(--space-4);
+    padding: calc(var(--space-4) + var(--space-6)) var(--space-4) var(--space-4);
     gap: var(--space-5);
   }
+}
+
+.practice-meta-row {
+  width: min(680px, 95vw);
+  max-width: 100%;
+  align-self: center;
+  margin-top: 0;
+
+  position: relative;
+  top: 40px;
+  z-index: 10;
+}
+
+.practice-typing-stage {
+  width: 100%;
+  max-width: min(680px, 95vw);
+}
+
+.practice-typing-wrap {
+  width: 100%;
+  max-width: none;
 }
 
 .practice-text-display {

--- a/src/routes/Home.tsx
+++ b/src/routes/Home.tsx
@@ -5,6 +5,7 @@
 
 import React, { useState, useMemo, useCallback, useEffect, useRef } from "react";
 import "./Home.css";
+import "./Test.css";
 import { getLessonSummaries } from "../core/lesson/homeData";
 import { getFingerMastery } from "../core/lesson/fingerMastery";
 import { getCoachMessage } from "../core/lesson/coachMessage";
@@ -527,15 +528,54 @@ function PracticeSessionView({
   onRestart,
 }: PracticeSessionViewProps) {
   const inputRef = useRef<HTMLInputElement>(null);
+  const [restartArmed, setRestartArmed] = useState(false);
+  const [capsLockOn, setCapsLockOn] = useState(false);
 
   useEffect(() => {
     inputRef.current?.focus();
   }, []);
 
   const focusInput = useCallback(() => inputRef.current?.focus(), []);
+  const clearRestartArm = useCallback(() => setRestartArmed(false), []);
+  const armRestart = useCallback(() => setRestartArmed(true), []);
+
+  const handleTypingAreaClick = useCallback(() => {
+    if (restartArmed) {
+      clearRestartArm();
+    }
+    focusInput();
+  }, [clearRestartArm, focusInput, restartArmed]);
 
   const handleKeyDown = useCallback(
     (e: React.KeyboardEvent) => {
+      setCapsLockOn(e.getModifierState("CapsLock"));
+
+      if (e.key === "Tab") {
+        e.preventDefault();
+        armRestart();
+        return;
+      }
+
+      if (restartArmed && e.key === "Escape") {
+        e.preventDefault();
+        clearRestartArm();
+        focusInput();
+        return;
+      }
+
+      if (restartArmed && e.key === "Enter") {
+        e.preventDefault();
+        clearRestartArm();
+        onRestart();
+        return;
+      }
+
+      if (restartArmed) {
+        e.preventDefault();
+        clearRestartArm();
+        return;
+      }
+
       if (e.key === "Escape") {
         e.preventDefault();
         onBack();
@@ -543,11 +583,11 @@ function PracticeSessionView({
       }
       onKeyDown(e);
     },
-    [onBack, onKeyDown]
+    [armRestart, clearRestartArm, focusInput, onBack, onKeyDown, onRestart, restartArmed]
   );
 
   return (
-    <div className="practice-root" onClick={focusInput}>
+    <div className="practice-root" onClick={handleTypingAreaClick}>
       <input
         ref={inputRef}
         className="practice-capture-input"
@@ -569,12 +609,33 @@ function PracticeSessionView({
         </span>
       </div>
       <div className="practice-body">
+        <div className="test-meta-row practice-meta-row" aria-live="polite">
+          {!restartArmed && (
+            <div className="test-restart-hint mono-label">
+              tab to restart
+            </div>
+          )}
+          {capsLockOn && <div className="test-caps-indicator mono-label">Caps Lock on</div>}
+        </div>
         <div className="practice-cue-label mono-label">type what you see</div>
-        <TypingDisplay
-          target={typing.target}
-          typed={typing.typed}
-          className="practice-text-display"
-        />
+        <div className={`test-typing-stage practice-typing-stage${restartArmed ? " test-typing-stage--armed" : ""}`}>
+          <div className="test-typing-wrap practice-typing-wrap">
+            <TypingDisplay
+              target={typing.target}
+              typed={typing.typed}
+              className="practice-text-display"
+            />
+          </div>
+          {restartArmed && (
+            <div className="test-restart-overlay" aria-live="polite" aria-label="Restart lesson confirmation">
+              <div className="test-restart-overlay__icon" aria-hidden="true">↻</div>
+              <div className="test-restart-overlay__body">
+                <div>press enter to restart</div>
+                <div>click on the screen to resume</div>
+              </div>
+            </div>
+          )}
+        </div>
         <div className="practice-callout">
           {callout ? (
             <>

--- a/src/routes/Learn.css
+++ b/src/routes/Learn.css
@@ -160,6 +160,21 @@
   align-items: center;
 }
 
+.learn-meta-row {
+  width: 100%;
+  max-width: 100%;
+}
+
+.learn-typing-stage {
+  width: 100%;
+  max-width: 100%;
+}
+
+.learn-typing-wrap {
+  width: 100%;
+  max-width: 100%;
+}
+
 /* When not in split layout, center the drill */
 .learn-body:not(.learn-body--split) .learn-drill-col {
   align-items: center;

--- a/src/routes/Learn.tsx
+++ b/src/routes/Learn.tsx
@@ -17,6 +17,7 @@ import React, {
 } from "react";
 import "../ui/Layout/LessonStage.css";
 import "./Learn.css";
+import "./Test.css";
 import { TypingDisplay } from "../ui/components/TypingDisplay";
 import { Keyboard } from "../ui/components/keyboard";
 import type { Settings } from "../core/storage/settingsStore";
@@ -121,6 +122,8 @@ export function Learn({ onBack, onCurriculumComplete, settings }: LearnProps) {
   );
   const [drill, setDrill] = useState<DrillState>(makeFreshDrillState());
   const [lastKey, setLastKey] = useState<string>("");
+  const [restartArmed, setRestartArmed] = useState(false);
+  const [capsLockOn, setCapsLockOn] = useState(false);
   const [verdict, setVerdict] = useState<"GOOD" | "BAD" | "IDLE" | "">("");
   const [wrongFingers, setWrongFingers] = useState<string[]>([]);
   const [showCamera, setShowCamera] = useState(false);
@@ -129,11 +132,15 @@ export function Learn({ onBack, onCurriculumComplete, settings }: LearnProps) {
   const inputRef = useRef<HTMLInputElement>(null);
   const step = LEARN_STEPS[stepIndex];
   const drillDone = useMemo(() => evaluateDrill(step, drill), [step, drill]);
+  const isTypingDrill =
+    step.drill.type === "keys" || step.drill.type === "sequence";
 
   /* Focus input whenever step changes */
   useEffect(() => {
     setDrill(makeFreshDrillState());
     setLastKey("");
+    setRestartArmed(false);
+    setCapsLockOn(false);
     lastGuidedKeyRef.current = null;
     if (step.drill.type !== "none") {
       setTimeout(() => inputRef.current?.focus(), 50);
@@ -216,17 +223,55 @@ export function Learn({ onBack, onCurriculumComplete, settings }: LearnProps) {
   useEffect(() => {
     const onKeyDown = (e: KeyboardEvent) => {
       if (e.key !== "Enter") return;
+      if (restartArmed) return;
       if (!drillDone) return;
       e.preventDefault();
       handleContinue();
     };
     document.addEventListener("keydown", onKeyDown);
     return () => document.removeEventListener("keydown", onKeyDown);
-  }, [drillDone, handleContinue]);
+  }, [drillDone, handleContinue, restartArmed]);
+
+  const clearRestartArm = useCallback(() => setRestartArmed(false), []);
+  const armRestart = useCallback(() => setRestartArmed(true), []);
+
+  const restartCurrentDrill = useCallback(() => {
+    setDrill(makeFreshDrillState());
+    setLastKey("");
+    setRestartArmed(false);
+    inputRef.current?.focus();
+  }, []);
 
   /* ── Key handler ───────────────────────────────────────────────────── */
   const handleKeyDown = useCallback(
     (e: React.KeyboardEvent<HTMLInputElement>) => {
+      setCapsLockOn(e.getModifierState("CapsLock"));
+
+      if (e.key === "Tab") {
+        e.preventDefault();
+        armRestart();
+        return;
+      }
+
+      if (restartArmed && e.key === "Escape") {
+        e.preventDefault();
+        clearRestartArm();
+        inputRef.current?.focus();
+        return;
+      }
+
+      if (restartArmed && e.key === "Enter") {
+        e.preventDefault();
+        restartCurrentDrill();
+        return;
+      }
+
+      if (restartArmed) {
+        e.preventDefault();
+        clearRestartArm();
+        return;
+      }
+
       if (step.drill.type === "none" || step.drill.type === "hold") return;
 
       const key = e.key === " " ? " " : e.key.toLowerCase();
@@ -286,8 +331,15 @@ export function Learn({ onBack, onCurriculumComplete, settings }: LearnProps) {
         });
       }
     },
-    [step],
+    [armRestart, clearRestartArm, restartArmed, restartCurrentDrill, step],
   );
+
+  const handleLearnBodyClick = useCallback(() => {
+    if (restartArmed) {
+      clearRestartArm();
+    }
+    inputRef.current?.focus();
+  }, [clearRestartArm, restartArmed]);
 
   const handleBack = useCallback(() => {
     if (stepIndex === 0) {
@@ -331,7 +383,7 @@ export function Learn({ onBack, onCurriculumComplete, settings }: LearnProps) {
 
       <div
         className={`learn-body${step.splitLayout ? " learn-body--split" : ""}`}
-        onClick={() => inputRef.current?.focus()}
+        onClick={handleLearnBodyClick}
       >
         <input
           ref={inputRef}
@@ -352,6 +404,16 @@ export function Learn({ onBack, onCurriculumComplete, settings }: LearnProps) {
         </div>
 
         <div className="learn-drill-col">
+          {isTypingDrill && (
+            <div className="test-meta-row learn-meta-row" aria-live="polite">
+              {!restartArmed && (
+                <div className="test-restart-hint mono-label">
+                  tab to restart
+                </div>
+              )}
+              {capsLockOn && <div className="test-caps-indicator mono-label">Caps Lock on</div>}
+            </div>
+          )}
           {settings?.showKeyboard !== false && (
             <div className="lesson-stage-keyboard-wrap">
               <Keyboard
@@ -364,56 +426,69 @@ export function Learn({ onBack, onCurriculumComplete, settings }: LearnProps) {
             </div>
           )}
 
-          <div className="learn-drill">
-            {step.drill.type === "keys" && (
-              <div className="learn-drill__keys">
-                {keysDrillKeys.map((k) => {
-                  const hits = drill.keyHits[k] ?? 0;
-                  const done = hits >= required;
-                  return (
-                    <div
-                      key={k}
-                      className={`learn-drill__key-target${done ? " learn-drill__key-target--done" : ""}`}
-                    >
-                      <span className="learn-drill__key-target-key">{k}</span>
-                      <div className="learn-drill__key-pips">
-                        {Array.from({ length: required }, (_, i) => (
-                          <div
-                            key={i}
-                            className={`learn-drill__key-pip${i < hits ? " learn-drill__key-pip--filled" : ""}`}
-                          />
-                        ))}
-                      </div>
-                    </div>
-                  );
-                })}
-              </div>
-            )}
-
-            {step.drill.type === "sequence" && (
-              <div className="learn-drill__sequence">
-                <TypingDisplay
-                  target={step.drill.sequence ?? ""}
-                  typed={drill.typed}
-                  showCursor={true}
-                  className="learn-typing-display"
-                />
-                {(step.drill.requiredReps ?? 1) > 1 && (
-                  <div className="learn-drill__rep-count">
-                    {drill.repsCompleted} / {step.drill.requiredReps} complete
+          <div className={`test-typing-stage learn-typing-stage${restartArmed ? " test-typing-stage--armed" : ""}`}>
+            <div className="test-typing-wrap learn-typing-wrap">
+              <div className="learn-drill">
+                {step.drill.type === "keys" && (
+                  <div className="learn-drill__keys">
+                    {keysDrillKeys.map((k) => {
+                      const hits = drill.keyHits[k] ?? 0;
+                      const done = hits >= required;
+                      return (
+                        <div
+                          key={k}
+                          className={`learn-drill__key-target${done ? " learn-drill__key-target--done" : ""}`}
+                        >
+                          <span className="learn-drill__key-target-key">{k}</span>
+                          <div className="learn-drill__key-pips">
+                            {Array.from({ length: required }, (_, i) => (
+                              <div
+                                key={i}
+                                className={`learn-drill__key-pip${i < hits ? " learn-drill__key-pip--filled" : ""}`}
+                              />
+                            ))}
+                          </div>
+                        </div>
+                      );
+                    })}
                   </div>
                 )}
-              </div>
-            )}
 
-            {step.drill.hint && (
-              <div className="learn-drill__hint mono-label">
-                {step.drill.hint}
-              </div>
-            )}
+                {step.drill.type === "sequence" && (
+                  <div className="learn-drill__sequence">
+                    <TypingDisplay
+                      target={step.drill.sequence ?? ""}
+                      typed={drill.typed}
+                      showCursor={true}
+                      className="learn-typing-display"
+                    />
+                    {(step.drill.requiredReps ?? 1) > 1 && (
+                      <div className="learn-drill__rep-count">
+                        {drill.repsCompleted} / {step.drill.requiredReps} complete
+                      </div>
+                    )}
+                  </div>
+                )}
 
-            {drillDone && step.drill.type !== "none" && (
-              <div className="learn-drill__complete">ready to continue</div>
+                {step.drill.hint && (
+                  <div className="learn-drill__hint mono-label">
+                    {step.drill.hint}
+                  </div>
+                )}
+
+                {drillDone && step.drill.type !== "none" && (
+                  <div className="learn-drill__complete">ready to continue</div>
+                )}
+              </div>
+            </div>
+            {restartArmed && (
+              <div className="test-restart-overlay" aria-live="polite" aria-label="Restart lesson confirmation">
+                <div className="test-restart-overlay__icon" aria-hidden="true">↻</div>
+                <div className="test-restart-overlay__body">
+                  <div>press enter to restart</div>
+                  <div>click on the screen to resume</div>
+                </div>
+              </div>
             )}
           </div>
 

--- a/src/routes/Test.css
+++ b/src/routes/Test.css
@@ -290,11 +290,87 @@
   letter-spacing: 0.04em;
 }
 
+.test-meta-row {
+  width: 100%;
+  max-width: 680px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-3);
+  min-height: 20px;
+}
+
+.test-restart-hint {
+  font-size: 11px;
+  color: var(--color-text-4, var(--color-text-3));
+  letter-spacing: 0.04em;
+}
+
+.test-caps-indicator {
+  padding: 3px 10px;
+  border-radius: 999px;
+  border: 1px solid color-mix(in srgb, #ffb84d 65%, transparent);
+  background: color-mix(in srgb, #ffb84d 18%, var(--color-surface));
+  font-size: 10px;
+  letter-spacing: 0.04em;
+  color: #ffd48a;
+  box-shadow: 0 0 14px rgba(255, 184, 77, 0.18);
+  white-space: nowrap;
+}
+
+.test-typing-stage {
+  position: relative;
+  width: 100%;
+  max-width: 680px;
+}
+
+.test-typing-stage--armed .test-typing-wrap {
+  opacity: 0.4;
+  filter: blur(3px);
+}
+
+.test-restart-overlay {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: var(--space-2);
+  pointer-events: none;
+}
+
+.test-restart-overlay__icon {
+  width: 48px;
+  height: 48px;
+  display: grid;
+  place-items: center;
+  border-radius: 999px;
+  border: 1px solid color-mix(in srgb, var(--color-line-3) 70%, transparent);
+  background: color-mix(in srgb, var(--color-surface) 82%, transparent);
+  backdrop-filter: blur(10px);
+  font-size: 24px;
+  color: var(--color-text);
+  box-shadow: 0 12px 30px rgba(0, 0, 0, 0.16);
+}
+
+.test-restart-overlay__body {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  align-items: center;
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: var(--color-accent);
+  text-align: center;
+  letter-spacing: 0.04em;
+}
+
 .test-typing-wrap {
   width: 100%;
   max-width: 680px;
   cursor: text;
-  transition: opacity 0.18s ease;
+  transition: opacity 0.18s ease, filter 0.18s ease;
 }
 
 .test-typing-wrap--transitioning {

--- a/src/routes/Test.tsx
+++ b/src/routes/Test.tsx
@@ -83,6 +83,8 @@ export function Test({ onBack, settings, initialMode = "standard" }: TestProps) 
   const [timerStarted, setTimerStarted] = useState(false);
   const [textTransitioning, setTextTransitioning] = useState(false);
   const [showCamera, setShowCamera] = useState(false);
+  const [restartArmed, setRestartArmed] = useState(false);
+  const [capsLockOn, setCapsLockOn] = useState(false);
   // server hand tracking data
   const [verdict, setVerdict] = useState<"GOOD" | "BAD" | "IDLE" | "">("");
   const [wrongFingers, setWrongFingers] = useState<string[]>([]);
@@ -97,6 +99,8 @@ export function Test({ onBack, settings, initialMode = "standard" }: TestProps) 
   const endSessionRef = useRef<() => import("../core/session/sessionTypes").SessionState | null>(null);
   const hasEndedRef = useRef(false);
   const startRef = useRef<number | null>(null);
+  const pauseStartedAtRef = useRef<number | null>(null);
+  const pausedDurationMsRef = useRef(0);
   const prevSettingsRef = useRef({
     duration,
     mode,
@@ -110,7 +114,6 @@ export function Test({ onBack, settings, initialMode = "standard" }: TestProps) 
   const typingRef = useRef<{ reset: () => void } | null>(null);
   const refillingRef = useRef(false);
   const lastGuidedKeyRef = useRef<string | null>(null);
-
   // Keep current text length in a ref so refill can check without stale closures
   const textLengthRef = useRef(0);
   textLengthRef.current = text.length;
@@ -177,6 +180,8 @@ export function Test({ onBack, settings, initialMode = "standard" }: TestProps) 
       ...config,
     });
     startRef.current = null;
+    pauseStartedAtRef.current = null;
+    pausedDurationMsRef.current = 0;
     setText(newText);
     setTimeLeft(duration);
     setTimerStarted(false);
@@ -280,7 +285,8 @@ export function Test({ onBack, settings, initialMode = "standard" }: TestProps) 
     if (testStatus !== "active") return;
     const interval = setInterval(() => {
       if (!startRef.current) return;
-      const elapsed = (Date.now() - startRef.current) / 1000;
+      if (pauseStartedAtRef.current) return;
+      const elapsed = (Date.now() - startRef.current - pausedDurationMsRef.current) / 1000;
       const remaining = Math.max(0, duration - elapsed);
       setTimeLeft(Math.ceil(remaining));
       if (remaining <= 0 && !hasEndedRef.current) {
@@ -327,6 +333,8 @@ export function Test({ onBack, settings, initialMode = "standard" }: TestProps) 
   const backToSetup = useCallback(() => {
     clearInterval(timerRef.current);
     startRef.current = null;
+    pauseStartedAtRef.current = null;
+    pausedDurationMsRef.current = 0;
     setTestStatus("setup");
     setTimerStarted(false);
     typingRef.current?.reset();
@@ -342,6 +350,21 @@ export function Test({ onBack, settings, initialMode = "standard" }: TestProps) 
     modeConfigRef.current = validatedConfig;
     regenerateTest();
   }, [createModeConfig, mode, testStatus, regenerateTest, validateModeConfig]);
+
+  const clearRestartArm = useCallback(() => {
+    if (pauseStartedAtRef.current) {
+      pausedDurationMsRef.current += Date.now() - pauseStartedAtRef.current;
+      pauseStartedAtRef.current = null;
+    }
+    setRestartArmed(false);
+  }, []);
+
+  const armRestart = useCallback(() => {
+    if (timerStarted && startRef.current && !pauseStartedAtRef.current) {
+      pauseStartedAtRef.current = Date.now();
+    }
+    setRestartArmed(true);
+  }, [timerStarted]);
 
   const retryWithSameSettings = useCallback(() => {
     hasEndedRef.current = false;
@@ -377,6 +400,57 @@ export function Test({ onBack, settings, initialMode = "standard" }: TestProps) 
     },
     [mode]
   );
+
+  useEffect(() => {
+    if (testStatus !== "active") {
+      clearRestartArm();
+      setCapsLockOn(false);
+    }
+  }, [clearRestartArm, testStatus]);
+
+  const handleActiveInputKeyDown = useCallback(
+    (e: React.KeyboardEvent<HTMLInputElement>) => {
+      setCapsLockOn(e.getModifierState("CapsLock"));
+
+      if (e.key === "Tab") {
+        e.preventDefault();
+        armRestart();
+        return;
+      }
+
+      if (restartArmed && e.key === "Escape") {
+        e.preventDefault();
+        clearRestartArm();
+        return;
+      }
+
+      if (restartArmed && e.key === "Enter") {
+        e.preventDefault();
+        clearRestartArm();
+        handleNewTest();
+        return;
+      }
+
+      if (restartArmed) {
+        e.preventDefault();
+        clearRestartArm();
+        return;
+      }
+
+      typing.handleKeyDown(e);
+    },
+    [armRestart, clearRestartArm, handleNewTest, restartArmed, typing]
+  );
+
+  const handleTypingAreaClick = useCallback(() => {
+    if (restartArmed) {
+      clearRestartArm();
+      typing.focus();
+      return;
+    }
+
+    typing.focus();
+  }, [clearRestartArm, restartArmed, typing]);
 
   /* ── Finished: show results ─────────────────────────────────────────── */
   if (testStatus === "finished" && typing.report) {
@@ -571,31 +645,48 @@ export function Test({ onBack, settings, initialMode = "standard" }: TestProps) 
         />
       </div>
 
-      <div className="lesson-stage-body" onClick={typing.focus}>
+      <div className="lesson-stage-body" onClick={handleTypingAreaClick}>
         <input
           ref={typing.inputRef}
-          onKeyDown={(e) => {
-            typing.handleKeyDown(e);
-          }}
+          onKeyDown={handleActiveInputKeyDown}
           className="test-hidden-input"
           readOnly
         />
 
         <div className="lesson-stage-content-col">
+          <div className="test-meta-row" aria-live="polite">
+            {!restartArmed && (
+              <div className="test-restart-hint mono-label">
+                tab to restart
+              </div>
+            )}
+            {capsLockOn && <div className="test-caps-indicator mono-label">Caps Lock on</div>}
+          </div>
           {!timerStarted && (
             <div className="test-idle-hint mono-label">
               Start typing — timer begins on first keypress
             </div>
           )}
 
-          <div
-            className={`test-typing-wrap${textTransitioning ? " test-typing-wrap--transitioning" : ""}`}
-          >
-            <TypingDisplay
-              target={text}
-              typed={typing.typed}
-              mode="viewport"
-            />
+          <div className={`test-typing-stage${restartArmed ? " test-typing-stage--armed" : ""}`}>
+            <div
+              className={`test-typing-wrap${textTransitioning ? " test-typing-wrap--transitioning" : ""}`}
+            >
+              <TypingDisplay
+                target={text}
+                typed={typing.typed}
+                mode="viewport"
+              />
+            </div>
+            {restartArmed && (
+              <div className="test-restart-overlay" aria-live="polite" aria-label="Restart test confirmation">
+                <div className="test-restart-overlay__icon" aria-hidden="true">↻</div>
+                <div className="test-restart-overlay__body">
+                  <div>press enter to restart</div>
+                  <div>click on the screen to resume</div>
+                </div>
+              </div>
+            )}
           </div>
 
           <FeedbackBanner verdict={verdict} wrongFingers={wrongFingers} />


### PR DESCRIPTION
Adds consistent typing UX improvements across Test, Home practice, and Learn lesson flows.

Changes:
- Implemented Monkeytype-style restart interaction:
  - Press Tab to arm restart overlay
  - Press Enter to restart session/drill
  - Click typing area or press Escape to cancel and resume
- Added centered restart overlay with dimmed/blurred background for clarity
- Paused/resumed timer correctly in Test mode when restart is armed/cancelled
- Added visible Caps Lock indicator to all typing screens
- Standardized "tab to restart" hint across pages (hidden when overlay is active)

UI / Layout fixes:
- Fixed Home practice layout so restart hint and Caps Lock badge are visible (not hidden behind header, made it 40px in practice-meta- in home.css since it was gettting stuck)
- Matched styling/behavior across Test, Learn, and Home
- Improved overlay readability on Learn/Test screens