### PR TITLE
added more test modes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -60,7 +60,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -1641,7 +1640,6 @@
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -1819,7 +1817,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1945,7 +1942,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -2709,7 +2705,6 @@
       "integrity": "sha512-VmQ+sifHUbI/IcSopBCF/HO3YiHQx/AVd3UVyYL6weuwW+HvON9VYn5l6Zl1WZzPWXPNZrSQpxwkkZ/VuvJZzg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -3989,7 +3984,6 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -4108,7 +4102,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
       "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -4118,7 +4111,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz",
       "integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -4604,7 +4596,6 @@
       "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -4974,7 +4965,6 @@
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/scripts/import-passages.mjs
+++ b/scripts/import-passages.mjs
@@ -1,0 +1,82 @@
+#!/usr/bin/env node
+
+import fs from "node:fs";
+import path from "node:path";
+
+const [, , inputPath, outputPath = "src/core/test/providers/localPassages.txt"] = process.argv;
+
+if (!inputPath) {
+  console.error("Usage: node scripts/import-passages.mjs <authorized-export.json|html|txt> [output.txt]");
+  process.exit(1);
+}
+
+function decodeEntities(value) {
+  return value
+    .replace(/&nbsp;/g, " ")
+    .replace(/&amp;/g, "&")
+    .replace(/&quot;/g, "\"")
+    .replace(/&#39;/g, "'")
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">");
+}
+
+function sanitizeText(value) {
+  return String(value ?? "")
+    .normalize("NFKC")
+    .replace(/<[^>]*>/g, " ")
+    .replace(/[\u0000-\u001f\u007f]/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+function normalizeEntry(entry, index) {
+  const text = sanitizeText(entry.text ?? entry.quote ?? entry.content ?? entry.body);
+  if (text.length < 80 || text.length > 900) return null;
+
+  const author = sanitizeText(entry.author ?? entry.by ?? entry.writer ?? "Unknown");
+  const source = sanitizeText(entry.source ?? entry.title ?? entry.work ?? "Authorized Text Export");
+  const id = sanitizeText(entry.id ?? `authorized-${index + 1}`);
+
+  return { id, text, author, source };
+}
+
+function parseJson(raw) {
+  const parsed = JSON.parse(raw);
+  const rows = Array.isArray(parsed) ? parsed : parsed.texts ?? parsed.quotes ?? parsed.passages ?? [];
+  return rows.map(normalizeEntry).filter(Boolean);
+}
+
+function parseHtml(raw) {
+  const decoded = decodeEntities(raw);
+  const rowMatches = decoded.match(/<tr[\s\S]*?<\/tr>/gi) ?? [];
+  const rows = rowMatches.flatMap((row) => {
+    const cells = [...row.matchAll(/<t[dh][^>]*>([\s\S]*?)<\/t[dh]>/gi)].map((match) => sanitizeText(match[1]));
+    if (cells.length < 2) return [];
+    const [source, , , text] = cells.length >= 4 ? cells : [cells[0], "", "", cells[cells.length - 1]];
+    return [{ text, source, author: "Unknown" }];
+  });
+  return rows.map(normalizeEntry).filter(Boolean);
+}
+
+function parseText(raw) {
+  return raw
+    .split(/\n{2,}/)
+    .map((text, index) => normalizeEntry({ text, source: "Authorized Text Export" }, index))
+    .filter(Boolean);
+}
+
+const raw = fs.readFileSync(inputPath, "utf8");
+const ext = path.extname(inputPath).toLowerCase();
+const passages = ext === ".json" ? parseJson(raw) : ext === ".html" || ext === ".htm" ? parseHtml(raw) : parseText(raw);
+
+if (passages.length === 0) {
+  console.error("No usable passages found. Expected entries with 80-900 characters of text.");
+  process.exit(1);
+}
+
+fs.mkdirSync(path.dirname(outputPath), { recursive: true });
+const textFile = passages
+  .map((passage) => `:: ${passage.id} | ${passage.author} | ${passage.source}\n${passage.text}`)
+  .join("\n\n");
+fs.writeFileSync(outputPath, `${textFile}\n`);
+console.log(`Wrote ${passages.length} passages to ${outputPath}`);

--- a/src/core/storage/keyStatsStore.ts
+++ b/src/core/storage/keyStatsStore.ts
@@ -58,6 +58,13 @@ function normalizeSample(value: Partial<KeyAttemptSample>): KeyAttemptSample | n
   };
 }
 
+function normalizeTrackedKey(char: string): string {
+  return char
+    .normalize("NFD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .toLowerCase();
+}
+
 function entryFromSamples(samples: KeyAttemptSample[]): KeyStatEntry {
   const windowedSamples = samples.slice(-KEY_ATTEMPT_WINDOW);
   const latencySamples = windowedSamples.filter((sample) => sample.latencyMs != null);
@@ -122,16 +129,38 @@ function getScoreForEntry(entry: KeyStatEntry): number {
   return Math.max(0, accuracy - getHesitationPenalty(avgLatencyMs));
 }
 
+function mergeEntries(a: KeyStatEntry, b: KeyStatEntry): KeyStatEntry {
+  if (a.samples.length > 0 || b.samples.length > 0) {
+    return entryFromSamples([...a.samples, ...b.samples]);
+  }
+
+  return {
+    attempts: a.attempts + b.attempts,
+    errors: a.errors + b.errors,
+    totalLatencyMs: a.totalLatencyMs + b.totalLatencyMs,
+    latencySamples: a.latencySamples + b.latencySamples,
+    slowAttempts: a.slowAttempts + b.slowAttempts,
+    samples: [],
+  };
+}
+
 export function getKeyStats(): KeyStats {
   const raw = getLS("kt_keystats", {}) as Record<string, StoredKeyStatEntry>;
-  return Object.fromEntries(
-    Object.entries(raw).map(([key, value]) => [key, normalizeEntry(value)]),
-  );
+  const normalized: KeyStats = {};
+
+  Object.entries(raw).forEach(([key, value]) => {
+    const normalizedKey = normalizeTrackedKey(key);
+    const entry = normalizeEntry(value);
+    const current = normalized[normalizedKey];
+    normalized[normalizedKey] = current ? mergeEntries(current, entry) : entry;
+  });
+
+  return normalized;
 }
 
 export function recordKeyStats(char: string, wasError: boolean, latencyMs?: number | null): void {
   const stats = getKeyStats();
-  const key = char.toLowerCase();
+  const key = normalizeTrackedKey(char);
   const sampleLatencyMs =
     typeof latencyMs === "number" &&
     Number.isFinite(latencyMs) &&

--- a/src/core/storage/settingsStore.ts
+++ b/src/core/storage/settingsStore.ts
@@ -5,6 +5,8 @@ export type KeyboardLightingMode = "solid" | "fingerBounds";
 
 export type Settings = {
   testDuration: number;
+  quotesModeEnabled: boolean;
+  codeModeEnabled: boolean;
   wordCount: number;
   testMode: "time" | "words";
   showKeyboard: boolean;
@@ -46,6 +48,8 @@ function normalizeLightingMode(value: unknown, fallback: KeyboardLightingMode): 
 
 const DEFAULT_SETTINGS: Settings = {
   testDuration: 60,
+  quotesModeEnabled: true,
+  codeModeEnabled: true,
   wordCount: 25,
   testMode: "time",
   showKeyboard: true,

--- a/src/core/test/codeSnippetGenerator.ts
+++ b/src/core/test/codeSnippetGenerator.ts
@@ -1,0 +1,46 @@
+import { getRandomLocalCodeSnippet, type NormalizedCodeSnippet } from "./providers/codeSnippetProvider";
+import type { CodeSnippetGeneratorOptions, TestGenerator } from "./types";
+
+function buildCodeText(snippet: NormalizedCodeSnippet): string {
+  return snippet.text;
+}
+
+export const codeSnippetGenerator: TestGenerator<CodeSnippetGeneratorOptions> = {
+  validateOptions(options) {
+    if (typeof options.includePunctuation !== "boolean") {
+      return { valid: false, reason: "Code generator requires includePunctuation to be a boolean." };
+    }
+
+    if (typeof options.includeNumbers !== "boolean") {
+      return { valid: false, reason: "Code generator requires includeNumbers to be a boolean." };
+    }
+
+    if (typeof options.randomCase !== "boolean") {
+      return { valid: false, reason: "Code generator requires randomCase to be a boolean." };
+    }
+
+    if (options.snippet != null && typeof options.snippet.text !== "string") {
+      return { valid: false, reason: "Code generator requires snippet text when a snippet is provided." };
+    }
+
+    return {
+      valid: true,
+      options: {
+        includePunctuation: true,
+        includeNumbers: true,
+        randomCase: false,
+        snippet: options.snippet,
+      },
+    };
+  },
+
+  generateInitialText({ durationSeconds, options }) {
+    void durationSeconds;
+    return buildCodeText(options.snippet ?? getRandomLocalCodeSnippet());
+  },
+
+  generateChunk({ wordCount, options }) {
+    void wordCount;
+    return buildCodeText(options.snippet ?? getRandomLocalCodeSnippet());
+  },
+};

--- a/src/core/test/providers/codeSnippetProvider.ts
+++ b/src/core/test/providers/codeSnippetProvider.ts
@@ -1,0 +1,56 @@
+import localCodeSnippets from "./localCodeSnippets.txt?raw";
+
+export type NormalizedCodeSnippet = {
+  text: string;
+  language: string;
+  source: string;
+  id: string;
+};
+
+function sanitizeText(value: unknown): string {
+  if (typeof value !== "string") return "";
+
+  return value
+    .normalize("NFKC")
+    .replace(/[\u0000-\u001f\u007f]/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+function isSnippet(value: unknown): value is NormalizedCodeSnippet {
+  const snippet = value as Partial<NormalizedCodeSnippet>;
+  return (
+    typeof snippet?.text === "string" &&
+    snippet.text.length > 0 &&
+    typeof snippet.language === "string" &&
+    typeof snippet.source === "string" &&
+    typeof snippet.id === "string"
+  );
+}
+
+function parseLocalCodeSnippets(raw: string): NormalizedCodeSnippet[] {
+  return raw
+    .split(/\n(?=:: )/g)
+    .map((block) => {
+      const [header = "", ...bodyLines] = block.trim().split("\n");
+      const match = header.match(/^::\s*([^|]+)\|\s*([^|]+)\|\s*(.+)$/);
+      if (!match) return null;
+
+      return {
+        id: sanitizeText(match[1]),
+        language: sanitizeText(match[2]),
+        source: sanitizeText(match[3]),
+        text: sanitizeText(bodyLines.join(" ")),
+      };
+    })
+    .filter(isSnippet);
+}
+
+export function getLocalCodeSnippets(): NormalizedCodeSnippet[] {
+  return parseLocalCodeSnippets(localCodeSnippets);
+}
+
+export function getRandomLocalCodeSnippet(): NormalizedCodeSnippet {
+  const snippets = getLocalCodeSnippets();
+  return snippets[Math.floor(Math.random() * snippets.length)];
+}

--- a/src/core/test/providers/localCodeSnippets.txt
+++ b/src/core/test/providers/localCodeSnippets.txt
@@ -1,0 +1,625 @@
+:: c-binary-search-1 | C | Binary Search
+int binarySearch(int a[], int n, int target) { int l = 0, r = n - 1; while (l <= r) { int m = l + (r - l) / 2; if (a[m] == target) return m; if (a[m] < target) l = m + 1; else r = m - 1; } return -1; }
+
+:: c-linear-search-1 | C | Linear Search
+int linearSearch(int a[], int n, int target) { for (int i = 0; i < n; i++) if (a[i] == target) return i; return -1; }
+
+:: c-bubble-sort-1 | C | Bubble Sort
+void bubbleSort(int a[], int n) { for (int i = 0; i < n - 1; i++) for (int j = 0; j < n - i - 1; j++) if (a[j] > a[j + 1]) { int t = a[j]; a[j] = a[j + 1]; a[j + 1] = t; } }
+
+:: c-selection-sort-1 | C | Selection Sort
+void selectionSort(int a[], int n) { for (int i = 0; i < n - 1; i++) { int min = i; for (int j = i + 1; j < n; j++) if (a[j] < a[min]) min = j; int t = a[i]; a[i] = a[min]; a[min] = t; } }
+
+:: c-insertion-sort-1 | C | Insertion Sort
+void insertionSort(int a[], int n) { for (int i = 1; i < n; i++) { int key = a[i], j = i - 1; while (j >= 0 && a[j] > key) { a[j + 1] = a[j]; j--; } a[j + 1] = key; } }
+
+:: c-merge-sort-1 | C | Merge Sort Call
+void mergeSort(int a[], int left, int right) { if (left >= right) return; int mid = left + (right - left) / 2; mergeSort(a, left, mid); mergeSort(a, mid + 1, right); merge(a, left, mid, right); }
+
+:: c-quick-sort-1 | C | Quick Sort Call
+void quickSort(int a[], int low, int high) { if (low < high) { int p = partition(a, low, high); quickSort(a, low, p - 1); quickSort(a, p + 1, high); } }
+
+:: c-kadane-1 | C | Maximum Subarray Sum
+int kadane(int a[], int n) { int best = a[0], current = a[0]; for (int i = 1; i < n; i++) { current = a[i] > current + a[i] ? a[i] : current + a[i]; best = best > current ? best : current; } return best; }
+
+:: c-prefix-sum-1 | C | Prefix Sum Array
+void prefixSum(int a[], int prefix[], int n) { prefix[0] = 0; for (int i = 0; i < n; i++) prefix[i + 1] = prefix[i] + a[i]; }
+
+:: c-two-pointer-sum-1 | C | Two Pointer Target Sum
+int twoPointerSum(int a[], int n, int target) { int l = 0, r = n - 1; while (l < r) { int sum = a[l] + a[r]; if (sum == target) return 1; if (sum < target) l++; else r--; } return 0; }
+
+:: c-sliding-window-1 | C | Max Window Sum
+int maxWindowSum(int a[], int n, int k) { int sum = 0; for (int i = 0; i < k; i++) sum += a[i]; int best = sum; for (int i = k; i < n; i++) { sum += a[i] - a[i - k]; if (sum > best) best = sum; } return best; }
+
+:: c-gcd-1 | C | Euclidean GCD
+int gcd(int a, int b) { while (b != 0) { int t = b; b = a % b; a = t; } return a; }
+
+:: c-lcm-1 | C | Least Common Multiple
+int lcm(int a, int b) { return a / gcd(a, b) * b; }
+
+:: c-fast-power-1 | C | Fast Exponentiation
+long long fastPower(long long base, long long exp) { long long result = 1; while (exp > 0) { if (exp % 2) result *= base; base *= base; exp /= 2; } return result; }
+
+:: c-factorial-recursive-1 | C | Recursive Factorial
+long long factorial(int n) { return n <= 1 ? 1 : n * factorial(n - 1); }
+
+:: c-fibonacci-dp-1 | C | Fibonacci DP
+int fib(int n) { if (n <= 1) return n; int a = 0, b = 1; for (int i = 2; i <= n; i++) { int c = a + b; a = b; b = c; } return b; }
+
+:: c-sieve-1 | C | Sieve of Eratosthenes
+void sieve(int prime[], int n) { for (int i = 0; i <= n; i++) prime[i] = 1; prime[0] = prime[1] = 0; for (int p = 2; p * p <= n; p++) if (prime[p]) for (int i = p * p; i <= n; i += p) prime[i] = 0; }
+
+:: c-palindrome-string-1 | C | Palindrome String
+int isPalindrome(char s[]) { int l = 0, r = strlen(s) - 1; while (l < r) if (s[l++] != s[r--]) return 0; return 1; }
+
+:: c-valid-parentheses-1 | C | Valid Parentheses Stack
+int isMatching(char open, char close) { return (open == '(' && close == ')') || (open == '[' && close == ']') || (open == '{' && close == '}'); }
+
+:: c-reverse-array-1 | C | Reverse Array
+void reverseArray(int a[], int n) { int l = 0, r = n - 1; while (l < r) { int t = a[l]; a[l++] = a[r]; a[r--] = t; } }
+
+:: c-bfs-queue-1 | C | BFS Queue Skeleton
+void bfs(int start) { int q[1000], front = 0, back = 0; visited[start] = 1; q[back++] = start; while (front < back) { int node = q[front++]; process(node); } }
+
+:: c-dfs-recursive-1 | C | DFS Recursive Skeleton
+void dfs(int node) { visited[node] = 1; process(node); for (int i = 0; i < graphSize[node]; i++) if (!visited[graph[node][i]]) dfs(graph[node][i]); }
+
+:: c-union-find-find-1 | C | Union Find Find
+int find(int x) { if (parent[x] != x) parent[x] = find(parent[x]); return parent[x]; }
+
+:: c-union-find-union-1 | C | Union Find Union
+void unite(int a, int b) { int rootA = find(a), rootB = find(b); if (rootA != rootB) parent[rootB] = rootA; }
+
+:: c-reverse-linked-list-1 | C | Reverse Linked List
+struct Node* reverseList(struct Node* head) { struct Node *prev = NULL, cur = head; while (cur) { struct Node next = cur->next; cur->next = prev; prev = cur; cur = next; } return prev; }
+
+:: cpp-binary-search-1 | C++ | Binary Search
+int binarySearch(vector<int>& nums, int target) { int l = 0, r = nums.size() - 1; while (l <= r) { int m = l + (r - l) / 2; if (nums[m] == target) return m; nums[m] < target ? l = m + 1 : r = m - 1; } return -1; }
+
+:: cpp-two-sum-1 | C++ | Two Sum Hash Map
+vector<int> twoSum(vector<int>& nums, int target) { unordered_map<int, int> seen; for (int i = 0; i < nums.size(); i++) { if (seen.count(target - nums[i])) return {seen[target - nums[i]], i}; seen[nums[i]] = i; } return {}; }
+
+:: cpp-sliding-window-1 | C++ | Longest Unique Substring
+int lengthOfLongestSubstring(string s) { unordered_set<char> seen; int l = 0, best = 0; for (int r = 0; r < s.size(); r++) { while (seen.count(s[r])) seen.erase(s[l++]); seen.insert(s[r]); best = max(best, r - l + 1); } return best; }
+
+:: cpp-prefix-sum-1 | C++ | Prefix Sum
+vector<int> prefixSum(vector<int>& nums) { vector<int> prefix(nums.size() + 1, 0); for (int i = 0; i < nums.size(); i++) prefix[i + 1] = prefix[i] + nums[i]; return prefix; }
+
+:: cpp-kadane-1 | C++ | Maximum Subarray
+int maxSubArray(vector<int>& nums) { int best = nums[0], cur = nums[0]; for (int i = 1; i < nums.size(); i++) { cur = max(nums[i], cur + nums[i]); best = max(best, cur); } return best; }
+
+:: cpp-merge-sort-1 | C++ | Merge Sort
+void mergeSort(vector<int>& a, int l, int r) { if (l >= r) return; int m = l + (r - l) / 2; mergeSort(a, l, m); mergeSort(a, m + 1, r); merge(a, l, m, r); }
+
+:: cpp-quick-sort-1 | C++ | Quick Sort
+void quickSort(vector<int>& a, int low, int high) { if (low < high) { int p = partition(a, low, high); quickSort(a, low, p - 1); quickSort(a, p + 1, high); } }
+
+:: cpp-bfs-1 | C++ | Breadth First Search
+void bfs(int start, vector<vector<int>>& graph) { queue<int> q; vector<bool> seen(graph.size()); seen[start] = true; q.push(start); while (!q.empty()) { int node = q.front(); q.pop(); for (int next : graph[node]) if (!seen[next]) seen[next] = true, q.push(next); } }
+
+:: cpp-dfs-1 | C++ | Depth First Search
+void dfs(int node, vector<vector<int>>& graph, vector<bool>& seen) { seen[node] = true; for (int next : graph[node]) if (!seen[next]) dfs(next, graph, seen); }
+
+:: cpp-dijkstra-1 | C++ | Dijkstra Shortest Path
+priority_queue<pair<int,int>, vector<pair<int,int>>, greater<pair<int,int>>> pq; dist[start] = 0; pq.push({0, start});
+
+:: cpp-topological-sort-1 | C++ | Topological Sort Queue
+queue<int> q; for (int i = 0; i < n; i++) if (indegree[i] == 0) q.push(i);
+
+:: cpp-union-find-find-1 | C++ | Union Find Find
+int find(int x) { return parent[x] == x ? x : parent[x] = find(parent[x]); }
+
+:: cpp-union-find-union-1 | C++ | Union Find Union
+void unite(int a, int b) { a = find(a); b = find(b); if (a != b) parent[b] = a; }
+
+:: cpp-heap-top-k-1 | C++ | Top K Elements
+priority_queue<int, vector<int>, greater<int>> heap; for (int x : nums) { heap.push(x); if (heap.size() > k) heap.pop(); }
+
+:: cpp-binary-tree-inorder-1 | C++ | Inorder Traversal
+void inorder(TreeNode* root, vector<int>& result) { if (!root) return; inorder(root->left, result); result.push_back(root->val); inorder(root->right, result); }
+
+:: cpp-tree-depth-1 | C++ | Maximum Tree Depth
+int maxDepth(TreeNode* root) { return root ? 1 + max(maxDepth(root->left), maxDepth(root->right)) : 0; }
+
+:: cpp-reverse-linked-list-1 | C++ | Reverse Linked List
+ListNode* reverseList(ListNode* head) { ListNode *prev = nullptr, cur = head; while (cur) { ListNode next = cur->next; cur->next = prev; prev = cur; cur = next; } return prev; }
+
+:: cpp-valid-parentheses-1 | C++ | Valid Parentheses
+bool isValid(string s) { stack<char> st; unordered_map<char,char> pairs{{')','('},{']','['},{'}','{'}}; for (char c : s) { if (pairs.count(c)) { if (st.empty() || st.top() != pairs[c]) return false; st.pop(); } else st.push(c); } return st.empty(); }
+
+:: cpp-lis-1 | C++ | Longest Increasing Subsequence
+int lengthOfLIS(vector<int>& nums) { vector<int> tails; for (int x : nums) { auto it = lower_bound(tails.begin(), tails.end(), x); if (it == tails.end()) tails.push_back(x); else *it = x; } return tails.size(); }
+
+:: cpp-knapsack-1 | C++ | Zero One Knapsack
+for (int i = 0; i < n; i++) for (int c = capacity; c >= weight[i]; c--) dp[c] = max(dp[c], dp[c - weight[i]] + value[i]);
+
+:: cpp-coin-change-1 | C++ | Coin Change DP
+vector<int> dp(amount + 1, amount + 1); dp[0] = 0; for (int coin : coins) for (int x = coin; x <= amount; x++) dp[x] = min(dp[x], dp[x - coin] + 1);
+
+:: cpp-sieve-1 | C++ | Sieve of Eratosthenes
+vector<bool> prime(n + 1, true); prime[0] = prime[1] = false; for (int p = 2; p * p <= n; p++) if (prime[p]) for (int i = p * p; i <= n; i += p) prime[i] = false;
+
+:: cpp-gcd-1 | C++ | Euclidean GCD
+int gcd(int a, int b) { while (b) { int t = b; b = a % b; a = t; } return a; }
+
+:: cpp-fast-power-1 | C++ | Fast Power
+long long power(long long base, long long exp) { long long ans = 1; while (exp) { if (exp & 1) ans *= base; base *= base; exp >>= 1; } return ans; }
+
+:: cpp-anagram-1 | C++ | Anagram Check
+bool isAnagram(string a, string b) { sort(a.begin(), a.end()); sort(b.begin(), b.end()); return a == b; }
+
+:: cpp-palindrome-1 | C++ | Palindrome Check
+bool isPalindrome(string s) { int l = 0, r = s.size() - 1; while (l < r) if (s[l++] != s[r--]) return false; return true; }
+
+:: python-binary-search-1 | Python | Binary Search
+def binary_search(nums, target):
+left, right = 0, len(nums) - 1
+while left <= right:
+mid = (left + right) // 2
+if nums[mid] == target: return mid
+if nums[mid] < target: left = mid + 1
+else: right = mid - 1
+return -1
+
+:: python-two-sum-1 | Python | Two Sum Hash Map
+def two_sum(nums, target):
+seen = {}
+for i, num in enumerate(nums):
+if target - num in seen: return [seen[target - num], i]
+seen[num] = i
+
+:: python-sliding-window-1 | Python | Longest Unique Substring
+def longest_unique(s):
+seen, left, best = set(), 0, 0
+for right, char in enumerate(s):
+while char in seen: seen.remove(s[left]); left += 1
+seen.add(char); best = max(best, right - left + 1)
+return best
+
+:: python-prefix-sum-1 | Python | Prefix Sum
+def prefix_sum(nums):
+prefix = [0]
+for num in nums: prefix.append(prefix[-1] + num)
+return prefix
+
+:: python-kadane-1 | Python | Maximum Subarray
+def max_subarray(nums):
+best = current = nums[0]
+for num in nums[1:]: current = max(num, current + num); best = max(best, current)
+return best
+
+:: python-merge-sort-1 | Python | Merge Sort
+def merge_sort(nums):
+if len(nums) <= 1: return nums
+mid = len(nums) // 2
+return merge(merge_sort(nums[:mid]), merge_sort(nums[mid:]))
+
+:: python-quick-sort-1 | Python | Quick Sort
+def quick_sort(nums):
+if len(nums) <= 1: return nums
+pivot = nums[0]
+return quick_sort([x for x in nums[1:] if x <= pivot]) + [pivot] + quick_sort([x for x in nums[1:] if x > pivot])
+
+:: python-bfs-1 | Python | Breadth First Search
+def bfs(start, graph):
+queue, seen = deque([start]), {start}
+while queue:
+node = queue.popleft()
+for nxt in graph[node]:
+if nxt not in seen: seen.add(nxt); queue.append(nxt)
+
+:: python-dfs-1 | Python | Depth First Search
+def dfs(node, graph, seen):
+seen.add(node)
+for nxt in graph[node]:
+if nxt not in seen: dfs(nxt, graph, seen)
+
+:: python-dijkstra-1 | Python | Dijkstra Shortest Path
+def dijkstra(start):
+dist, heap = defaultdict(lambda: float("inf")), [(0, start)]
+dist[start] = 0
+while heap:
+cost, node = heapq.heappop(heap)
+
+:: python-topological-sort-1 | Python | Topological Sort Queue
+queue = deque([node for node in graph if indegree[node] == 0])
+
+:: python-union-find-find-1 | Python | Union Find Find
+def find(x):
+if parent[x] != x: parent[x] = find(parent[x])
+return parent[x]
+
+:: python-union-find-union-1 | Python | Union Find Union
+def union(a, b):
+root_a, root_b = find(a), find(b)
+if root_a != root_b: parent[root_b] = root_a
+
+:: python-heap-top-k-1 | Python | Top K Elements
+top_k = heapq.nlargest(k, nums)
+
+:: python-tree-inorder-1 | Python | Inorder Traversal
+def inorder(root):
+return inorder(root.left) + [root.val] + inorder(root.right) if root else []
+
+:: python-tree-depth-1 | Python | Maximum Tree Depth
+def max_depth(root):
+return 0 if not root else 1 + max(max_depth(root.left), max_depth(root.right))
+
+:: python-reverse-linked-list-1 | Python | Reverse Linked List
+def reverse_list(head):
+prev, cur = None, head
+while cur: cur.next, prev, cur = prev, cur, cur.next
+return prev
+
+:: python-valid-parentheses-1 | Python | Valid Parentheses
+def is_valid(s):
+stack, pairs = [], {")": "(", "]": "[", "}": "{"}
+for char in s:
+if char in pairs:
+if not stack or stack.pop() != pairs[char]: return False
+else: stack.append(char)
+return not stack
+
+:: python-lis-1 | Python | Longest Increasing Subsequence
+def length_of_lis(nums):
+tails = []
+for num in nums:
+i = bisect_left(tails, num)
+if i == len(tails): tails.append(num)
+else: tails[i] = num
+return len(tails)
+
+:: python-knapsack-1 | Python | Zero One Knapsack
+dp = [0] * (capacity + 1)
+for weight, value in items:
+for c in range(capacity, weight - 1, -1): dp[c] = max(dp[c], dp[c - weight] + value)
+
+:: python-coin-change-1 | Python | Coin Change DP
+dp = [0] + [float("inf")] * amount
+for coin in coins:
+for x in range(coin, amount + 1): dp[x] = min(dp[x], dp[x - coin] + 1)
+
+:: python-sieve-1 | Python | Sieve of Eratosthenes
+prime = [True] * (n + 1); prime[0] = prime[1] = False
+for p in range(2, int(n ** 0.5) + 1):
+if prime[p]:
+for i in range(p * p, n + 1, p): prime[i] = False
+
+:: python-gcd-1 | Python | Euclidean GCD
+def gcd(a, b):
+while b: a, b = b, a % b
+return a
+
+:: python-fast-power-1 | Python | Fast Power
+def fast_power(base, exp):
+result = 1
+while exp:
+if exp & 1: result *= base
+base *= base; exp >>= 1
+return result
+
+:: python-anagram-1 | Python | Anagram Check
+def is_anagram(a, b):
+return Counter(a) == Counter(b)
+
+:: python-palindrome-1 | Python | Palindrome Check
+def is_palindrome(text):
+return text == text[::-1]
+
+:: java-binary-search-1 | Java | Binary Search
+int binarySearch(int[] nums, int target) { int l = 0, r = nums.length - 1; while (l <= r) { int m = l + (r - l) / 2; if (nums[m] == target) return m; if (nums[m] < target) l = m + 1; else r = m - 1; } return -1; }
+
+:: java-two-sum-1 | Java | Two Sum Hash Map
+int[] twoSum(int[] nums, int target) { Map<Integer, Integer> seen = new HashMap<>(); for (int i = 0; i < nums.length; i++) { if (seen.containsKey(target - nums[i])) return new int[]{seen.get(target - nums[i]), i}; seen.put(nums[i], i); } return new int[]{}; }
+
+:: java-sliding-window-1 | Java | Longest Unique Substring
+int longestUnique(String s) { Set<Character> seen = new HashSet<>(); int left = 0, best = 0; for (int right = 0; right < s.length(); right++) { while (seen.contains(s.charAt(right))) seen.remove(s.charAt(left++)); seen.add(s.charAt(right)); best = Math.max(best, right - left + 1); } return best; }
+
+:: java-prefix-sum-1 | Java | Prefix Sum
+int[] prefixSum(int[] nums) { int[] prefix = new int[nums.length + 1]; for (int i = 0; i < nums.length; i++) prefix[i + 1] = prefix[i] + nums[i]; return prefix; }
+
+:: java-kadane-1 | Java | Maximum Subarray
+int maxSubArray(int[] nums) { int best = nums[0], cur = nums[0]; for (int i = 1; i < nums.length; i++) { cur = Math.max(nums[i], cur + nums[i]); best = Math.max(best, cur); } return best; }
+
+:: java-merge-sort-1 | Java | Merge Sort Call
+void mergeSort(int[] nums, int left, int right) { if (left >= right) return; int mid = left + (right - left) / 2; mergeSort(nums, left, mid); mergeSort(nums, mid + 1, right); merge(nums, left, mid, right); }
+
+:: java-quick-sort-1 | Java | Quick Sort Call
+void quickSort(int[] nums, int low, int high) { if (low < high) { int p = partition(nums, low, high); quickSort(nums, low, p - 1); quickSort(nums, p + 1, high); } }
+
+:: java-bfs-1 | Java | Breadth First Search
+void bfs(int start, List<List<Integer>> graph) { Queue<Integer> q = new LinkedList<>(); boolean[] seen = new boolean[graph.size()]; seen[start] = true; q.add(start); while (!q.isEmpty()) { int node = q.poll(); for (int next : graph.get(node)) if (!seen[next]) { seen[next] = true; q.add(next); } } }
+
+:: java-dfs-1 | Java | Depth First Search
+void dfs(int node, List<List<Integer>> graph, boolean[] seen) { seen[node] = true; for (int next : graph.get(node)) if (!seen[next]) dfs(next, graph, seen); }
+
+:: java-dijkstra-1 | Java | Dijkstra Setup
+PriorityQueue<int[]> pq = new PriorityQueue<>((a, b) -> a[0] - b[0]); dist[start] = 0; pq.add(new int[]{0, start});
+
+:: java-topological-sort-1 | Java | Topological Sort Queue
+Queue<Integer> q = new LinkedList<>(); for (int i = 0; i < n; i++) if (indegree[i] == 0) q.add(i);
+
+:: java-union-find-find-1 | Java | Union Find Find
+int find(int x) { if (parent[x] != x) parent[x] = find(parent[x]); return parent[x]; }
+
+:: java-union-find-union-1 | Java | Union Find Union
+void union(int a, int b) { int rootA = find(a), rootB = find(b); if (rootA != rootB) parent[rootB] = rootA; }
+
+:: java-heap-top-k-1 | Java | Top K Elements
+PriorityQueue<Integer> heap = new PriorityQueue<>(); for (int x : nums) { heap.add(x); if (heap.size() > k) heap.poll(); }
+
+:: java-tree-inorder-1 | Java | Inorder Traversal
+void inorder(TreeNode root, List<Integer> result) { if (root == null) return; inorder(root.left, result); result.add(root.val); inorder(root.right, result); }
+
+:: java-tree-depth-1 | Java | Maximum Tree Depth
+int maxDepth(TreeNode root) { return root == null ? 0 : 1 + Math.max(maxDepth(root.left), maxDepth(root.right)); }
+
+:: java-reverse-linked-list-1 | Java | Reverse Linked List
+ListNode reverseList(ListNode head) { ListNode prev = null, cur = head; while (cur != null) { ListNode next = cur.next; cur.next = prev; prev = cur; cur = next; } return prev; }
+
+:: java-valid-parentheses-1 | Java | Valid Parentheses
+boolean isValid(String s) { Stack<Character> stack = new Stack<>(); Map<Character, Character> pairs = Map.of(')', '(', ']', '[', '}', '{'); for (char c : s.toCharArray()) { if (pairs.containsKey(c)) { if (stack.isEmpty() || stack.pop() != pairs.get(c)) return false; } else stack.push(c); } return stack.isEmpty(); }
+
+:: java-lis-1 | Java | Longest Increasing Subsequence
+int lengthOfLIS(int[] nums) { int[] tails = new int[nums.length]; int size = 0; for (int x : nums) { int i = Arrays.binarySearch(tails, 0, size, x); if (i < 0) i = -(i + 1); tails[i] = x; if (i == size) size++; } return size; }
+
+:: java-knapsack-1 | Java | Zero One Knapsack
+for (int i = 0; i < n; i++) for (int c = capacity; c >= weight[i]; c--) dp[c] = Math.max(dp[c], dp[c - weight[i]] + value[i]);
+
+:: java-coin-change-1 | Java | Coin Change DP
+int[] dp = new int[amount + 1]; Arrays.fill(dp, amount + 1); dp[0] = 0; for (int coin : coins) for (int x = coin; x <= amount; x++) dp[x] = Math.min(dp[x], dp[x - coin] + 1);
+
+:: java-sieve-1 | Java | Sieve of Eratosthenes
+boolean[] prime = new boolean[n + 1]; Arrays.fill(prime, true); prime[0] = prime[1] = false; for (int p = 2; p * p <= n; p++) if (prime[p]) for (int i = p * p; i <= n; i += p) prime[i] = false;
+
+:: java-gcd-1 | Java | Euclidean GCD
+int gcd(int a, int b) { while (b != 0) { int t = b; b = a % b; a = t; } return a; }
+
+:: java-fast-power-1 | Java | Fast Power
+long fastPower(long base, long exp) { long result = 1; while (exp > 0) { if ((exp & 1) == 1) result *= base; base *= base; exp >>= 1; } return result; }
+
+:: java-anagram-1 | Java | Anagram Check
+boolean isAnagram(String a, String b) { char[] x = a.toCharArray(), y = b.toCharArray(); Arrays.sort(x); Arrays.sort(y); return Arrays.equals(x, y); }
+
+:: java-palindrome-1 | Java | Palindrome Check
+boolean isPalindrome(String s) { int l = 0, r = s.length() - 1; while (l < r) if (s.charAt(l++) != s.charAt(r--)) return false; return true; }
+
+:: csharp-merge-intervals-1 | C# | Merge Intervals
+intervals.Sort((a, b) => a[0].CompareTo(b[0])); foreach (var x in intervals) if (merged.Count == 0 || merged[^1][1] < x[0]) merged.Add(x); else merged[^1][1] = Math.Max(merged[^1][1], x[1]);
+
+:: csharp-kmp-prefix-1 | C# | KMP Prefix Table
+int[] lps = new int[p.Length]; for (int i = 1, len = 0; i < p.Length;) { if (p[i] == p[len]) lps[i++] = ++len; else if (len > 0) len = lps[len - 1]; else lps[i++] = 0; }
+
+:: csharp-rolling-hash-1 | C# | Rolling Hash
+long hash = 0, mod = 1_000_000_007, baseNum = 257; foreach (char c in text) hash = (hash * baseNum + c) % mod;
+
+:: csharp-reservoir-sampling-1 | C# | Reservoir Sampling
+int chosen = items[0]; for (int i = 1; i < items.Length; i++) if (random.Next(i + 1) == 0) chosen = items[i];
+
+:: csharp-trie-insert-1 | C# | Trie Insert
+foreach (char c in word) node = node.Children.TryGetValue(c, out var next) ? next : node.Children[c] = new TrieNode(); node.IsWord = true;
+
+:: csharp-segment-tree-query-1 | C# | Segment Tree Range Query
+int Query(int node, int l, int r, int ql, int qr) { if (qr < l || r < ql) return 0; if (ql <= l && r <= qr) return tree[node]; int m = (l + r) / 2; return Query(node * 2, l, m, ql, qr) + Query(node * 2 + 1, m + 1, r, ql, qr); }
+
+:: csharp-floyd-cycle-1 | C# | Floyd Cycle Detection
+bool HasCycle(ListNode head) { var slow = head; var fast = head; while (fast?.Next != null) { slow = slow.Next; fast = fast.Next.Next; if (slow == fast) return true; } return false; }
+
+:: csharp-astar-heuristic-1 | C# | A Star Manhattan Heuristic
+int Heuristic(Point a, Point b) => Math.Abs(a.X - b.X) + Math.Abs(a.Y - b.Y);
+
+:: go-next-greater-1 | Go | Next Greater Element
+stack := []int{}; for i := len(nums)-1; i >= 0; i-- { for len(stack) > 0 && stack[len(stack)-1] <= nums[i] { stack = stack[:len(stack)-1] }; next[i] = -1; if len(stack) > 0 { next[i] = stack[len(stack)-1] }; stack = append(stack, nums[i]) }
+
+:: go-flood-fill-1 | Go | Flood Fill
+func fill(r, c int) { if r < 0 || c < 0 || r == len(grid) || c == len(grid[0]) || grid[r][c] != old { return }; grid[r][c] = color; fill(r+1,c); fill(r-1,c); fill(r,c+1); fill(r,c-1) }
+
+:: go-fenwick-add-1 | Go | Fenwick Tree Update
+func add(bit []int, i, delta int) { for i < len(bit) { bit[i] += delta; i += i & -i } }
+
+:: go-quickselect-1 | Go | Quickselect Partition
+pivot := nums[right]; p := left; for i := left; i < right; i++ { if nums[i] <= pivot { nums[i], nums[p] = nums[p], nums[i]; p++ } }; nums[p], nums[right] = nums[right], nums[p]
+
+:: go-edit-distance-1 | Go | Edit Distance DP
+dp := make([][]int, len(a)+1); for i := range dp { dp[i] = make([]int, len(b)+1) }
+
+:: go-rabin-karp-1 | Go | Rabin Karp Hash Match
+if windowHash == patternHash && text[i:i+len(pattern)] == pattern { return i }
+
+:: go-rotate-matrix-1 | Go | Rotate Matrix
+for i := 0; i < n; i++ { for j := i+1; j < n; j++ { matrix[i][j], matrix[j][i] = matrix[j][i], matrix[i][j] } }; for i := range matrix { slices.Reverse(matrix[i]) }
+
+:: go-tarjan-lowlink-1 | Go | Tarjan Low Link Update
+low[u] = min(low[u], low[v])
+
+:: rust-kruskal-1 | Rust | Kruskal Edge Selection
+edges.sort_by_key(|e| e.weight); for e in edges { if find(e.u) != find(e.v) { union(e.u, e.v); mst.push(e); } }
+
+:: rust-bellman-ford-1 | Rust | Bellman Ford Relaxation
+for _ in 0..n-1 { for &(u, v, w) in &edges { if dist[u] != i32::MAX && dist[u] + w < dist[v] { dist[v] = dist[u] + w; } } }
+
+:: rust-z-algorithm-1 | Rust | Z Algorithm Window
+if i <= r { z[i] = z[i - l].min(r - i + 1); }
+
+:: rust-counting-sort-1 | Rust | Counting Sort
+for &x in &nums { count[x as usize] += 1; }
+
+:: rust-top-k-frequency-1 | Rust | Top K Frequent
+let mut freq = std::collections::HashMap::new(); for x in nums { *freq.entry(x).or_insert(0) += 1; }
+
+:: rust-activity-selection-1 | Rust | Activity Selection
+activities.sort_by_key(|a| a.end); let chosen: Vec<_> = activities.into_iter().filter(|a| { let ok = a.start >= last_end; if ok { last_end = a.end; } ok }).collect();
+
+:: rust-prefix-xor-1 | Rust | Prefix XOR
+let mut prefix = vec![0]; for &x in &nums { prefix.push(prefix.last().unwrap() ^ x); }
+
+:: rust-binary-lifting-1 | Rust | Binary Lifting Table
+up[k][v] = up[k - 1][up[k - 1][v]];
+
+:: kotlin-floyd-warshall-1 | Kotlin | Floyd Warshall
+for (k in 0 until n) for (i in 0 until n) for (j in 0 until n) dist[i][j] = minOf(dist[i][j], dist[i][k] + dist[k][j])
+
+:: kotlin-dutch-flag-1 | Kotlin | Dutch National Flag
+while (mid <= high) when (nums[mid]) { 0 -> nums[low] = nums[mid].also { nums[mid++] = nums[low++] }; 1 -> mid++; else -> nums[mid] = nums[high].also { nums[high--] = nums[mid] } }
+
+:: kotlin-product-except-self-1 | Kotlin | Product Except Self
+val ans = IntArray(nums.size) { 1 }; var left = 1; for (i in nums.indices) { ans[i] = left; left *= nums[i] }
+
+:: kotlin-word-break-1 | Kotlin | Word Break DP
+val dp = BooleanArray(s.length + 1); dp[0] = true; for (i in 1..s.length) dp[i] = words.any { i >= it.length && dp[i - it.length] && s.substring(i - it.length, i) == it }
+
+:: kotlin-permutations-1 | Kotlin | Backtracking Permutations
+fun backtrack(path: MutableList<Int>) { if (path.size == nums.size) result.add(path.toList()) else for (x in nums) if (x !in path) { path.add(x); backtrack(path); path.removeAt(path.lastIndex) } }
+
+:: kotlin-nqueens-safe-1 | Kotlin | N Queens Safe Check
+fun safe(r: Int, c: Int) = rows[r] == 0 && diag1[r - c + n] == 0 && diag2[r + c] == 0
+
+:: kotlin-spiral-matrix-1 | Kotlin | Spiral Matrix Traversal
+while (top <= bottom && left <= right) { for (c in left..right) ans.add(a[top][c]); top++ }
+
+:: kotlin-median-heaps-1 | Kotlin | Two Heap Median
+if (low.size > high.size + 1) high.add(low.poll()) else if (high.size > low.size) low.add(high.poll())
+
+:: swift-lcs-1 | Swift | Longest Common Subsequence
+for i in 1...a.count { for j in 1...b.count { dp[i][j] = a[i-1] == b[j-1] ? dp[i-1][j-1] + 1 : max(dp[i-1][j], dp[i][j-1]) } }
+
+:: swift-min-stack-1 | Swift | Min Stack Push
+stack.append(x); mins.append(min(x, mins.last ?? x))
+
+:: swift-sweep-line-1 | Swift | Maximum Overlap Sweep Line
+for event in events.sorted(by: { $0.time < $1.time }) { active += event.delta; best = max(best, active) }
+
+:: swift-level-order-1 | Swift | Binary Tree Level Order
+while !queue.isEmpty { let node = queue.removeFirst(); values.append(node.val); if let l = node.left { queue.append(l) }; if let r = node.right { queue.append(r) } }
+
+:: swift-majority-vote-1 | Swift | Boyer Moore Majority Vote
+for x in nums { if count == 0 { candidate = x }; count += x == candidate ? 1 : -1 }
+
+:: swift-expand-palindrome-1 | Swift | Expand Around Center
+while left >= 0 && right < chars.count && chars[left] == chars[right] { left -= 1; right += 1 }
+
+:: swift-topological-sort-1 | Swift | Topological Sort
+while !queue.isEmpty { let node = queue.removeFirst(); order.append(node); for next in graph[node] { indegree[next] -= 1; if indegree[next] == 0 { queue.append(next) } } }
+
+:: swift-weighted-random-1 | Swift | Weighted Random Choice
+let r = Int.random(in: 1...totalWeight); let choice = prefix.firstIndex { $0 >= r }!
+
+:: php-run-length-1 | PHP | Run Length Encoding
+$result = ""; for ($i = 0; $i < strlen($s); $i++) { $count = 1; while ($i + 1 < strlen($s) && $s[$i] === $s[$i + 1]) { $count++; $i++; } $result .= $s[$i] . $count; }
+
+:: php-prime-factorization-1 | PHP | Prime Factorization
+for ($d = 2; $d * $d <= $n; $d++) while ($n % $d == 0) { $factors[] = $d; $n /= $d; } if ($n > 1) $factors[] = $n;
+
+:: php-group-anagrams-1 | PHP | Group Anagrams
+foreach ($words as $word) { $chars = str_split($word); sort($chars); $groups[implode("", $chars)][] = $word; }
+
+:: php-grid-bfs-1 | PHP | Grid Shortest Path BFS
+$queue = [[0, 0, 0]]; while ($queue) { [$r, $c, $d] = array_shift($queue); if ($r == $targetR && $c == $targetC) return $d; }
+
+:: php-memoization-1 | PHP | Memoized Recursion
+function fib($n, &$memo = []) { if ($n < 2) return $n; return $memo[$n] ??= fib($n - 1, $memo) + fib($n - 2, $memo); }
+
+:: php-common-prefix-1 | PHP | Longest Common Prefix
+$prefix = $words[0]; foreach ($words as $word) while (strpos($word, $prefix) !== 0) $prefix = substr($prefix, 0, -1);
+
+:: ruby-connected-components-1 | Ruby | Connected Components
+def dfs(v, graph, seen); seen[v] = true; graph[v].each { |n| dfs(n, graph, seen) unless seen[n] }; end
+
+:: ruby-generate-parentheses-1 | Ruby | Generate Parentheses
+def gen(s, open, close, n, out); out << s if s.length == 2*n; gen(s+"(", open+1, close, n, out) if open < n; gen(s+")", open, close+1, n, out) if close < open; end
+
+:: ruby-bitmask-subsets-1 | Ruby | Bitmask Subsets
+subsets = (0...(1 << nums.length)).map { |mask| nums.each_index.select { |i| mask & (1 << i) != 0 }.map { |i| nums[i] } }
+
+:: ruby-consecutive-sequence-1 | Ruby | Longest Consecutive Sequence
+set = nums.to_set; best = nums.select { |x| !set.include?(x - 1) }.map { |x| y = x; y += 1 while set.include?(y); y - x }.max
+
+:: ruby-stable-partition-1 | Ruby | Stable Partition
+partitioned = nums.select { |x| x < pivot } + nums.reject { |x| x < pivot }
+
+:: ruby-levenshtein-1 | Ruby | Levenshtein Distance Setup
+dp = Array.new(a.length + 1) { Array.new(b.length + 1, 0) }
+
+:: dart-rotate-array-1 | Dart | Rotate Array
+nums.setAll(0, [...nums.sublist(nums.length - k), ...nums.sublist(0, nums.length - k)]);
+
+:: dart-invert-tree-1 | Dart | Invert Binary Tree
+TreeNode? invert(TreeNode? root) { if (root == null) return null; final left = invert(root.left); root.left = invert(root.right); root.right = left; return root; }
+
+:: dart-sudoku-check-1 | Dart | Valid Sudoku Row
+final valid = row.where((x) => x != ".").toSet().length == row.where((x) => x != ".").length;
+
+:: dart-postfix-eval-1 | Dart | Postfix Expression Evaluation
+for (final t in tokens) ops.contains(t) ? stack.add(apply(stack.removeLast(), stack.removeLast(), t)) : stack.add(int.parse(t));
+
+:: dart-range-sum-1 | Dart | Prefix Range Sum
+int rangeSum(int left, int right) => prefix[right + 1] - prefix[left];
+
+:: dart-island-dfs-1 | Dart | Number Of Islands DFS
+void sink(int r, int c) { if (r < 0 || c < 0 || r >= grid.length || c >= grid[0].length || grid[r][c] != "1") return; grid[r][c] = "0"; sink(r+1,c); sink(r-1,c); sink(r,c+1); sink(r,c-1); }
+
+:: scala-graph-coloring-1 | Scala | Graph Coloring Check
+def canColor(v: Int, color: Int): Boolean = graph(v).forall(neighbor => colors(neighbor) != color)
+
+:: scala-memo-fib-1 | Scala | Memoized Fibonacci
+def fib(n: Int): BigInt = memo.getOrElseUpdate(n, if (n < 2) n else fib(n - 1) + fib(n - 2))
+
+:: scala-circular-kadane-1 | Scala | Circular Maximum Subarray
+val answer = math.max(kadane(nums), nums.sum + kadane(nums.map(-_)))
+
+:: scala-top-k-frequency-1 | Scala | Top K Frequent
+val topK = nums.groupBy(identity).view.mapValues(.length).toSeq.sortBy(-.2).take(k).map(._1)
+
+:: scala-transpose-1 | Scala | Matrix Transpose
+val transposed = matrix.transpose
+
+:: scala-brackets-fold-1 | Scala | Balanced Brackets
+val ok = s.foldLeft(List.empty[Char])((stack, c) => if ("([{".contains(c)) c :: stack else stack).isEmpty
+
+:: elixir-flatten-list-1 | Elixir | Flatten Nested List
+def flatten([]), do: []; def flatten([h | t]) when is_list(h), do: flatten(h) ++ flatten(t); def flatten([h | t]), do: [h | flatten(t)]
+
+:: elixir-combinations-1 | Elixir | Generate Combinations
+def comb(_, 0), do: [[]]; def comb([], _), do: []; def comb([h | t], k), do: Enum.map(comb(t, k - 1), &[h | &1]) ++ comb(t, k)
+
+:: elixir-extended-gcd-1 | Elixir | Extended Euclidean Algorithm
+def egcd(a, 0), do: {a, 1, 0}; def egcd(a, b), do: (fn {g, x, y} -> {g, y, x - div(a, b) * y} end).(egcd(b, rem(a, b)))
+
+:: elixir-run-length-1 | Elixir | Run Length Encoding
+encoded = Enum.chunk_by(chars, & &1) |> Enum.map(fn group -> {hd(group), length(group)} end)
+
+:: elixir-bfs-layer-1 | Elixir | BFS Layer Expansion
+next_layer = layer |> Enum.flat_map(&Map.get(graph, &1, [])) |> Enum.reject(&MapSet.member?(seen, &1))
+
+:: elixir-moving-average-1 | Elixir | Moving Average
+averages = values |> Enum.chunk_every(k, 1, :discard) |> Enum.map(&(Enum.sum(&1) / k))
+
+:: julia-newton-root-1 | Julia | Newton Method
+x = x - f(x) / fprime(x)
+
+:: julia-gradient-step-1 | Julia | Gradient Descent Step
+weights .-= learning_rate .* gradient
+
+:: julia-kmeans-assign-1 | Julia | K Means Assignment
+labels = [argmin([sum((x .- c).^2) for c in centroids]) for x in points]
+
+:: julia-convolution-1 | Julia | One Dimensional Convolution
+y[i] = sum(kernel[j] * signal[i - j + 1] for j in 1:length(kernel) if i - j + 1 in eachindex(signal))
+
+:: julia-monte-carlo-pi-1 | Julia | Monte Carlo Pi Estimate
+pi_estimate = 4 * count(rand()^2 + rand()^2 <= 1 for _ in 1:n) / n
+
+:: julia-markov-step-1 | Julia | Markov Chain Step
+state = transition_matrix' * state
+
+:: r-bootstrap-1 | R | Bootstrap Resample
+sampled <- sample(values, size = length(values), replace = TRUE)
+
+:: r-moving-average-1 | R | Moving Average
+moving_avg <- stats::filter(values, rep(1 / k, k), sides = 1)
+
+:: r-zscore-1 | R | Z Score Standardization
+z <- (values - mean(values)) / sd(values)
+
+:: r-train-test-split-1 | R | Train Test Split
+train_idx <- sample(seq_len(nrow(data)), size = floor(0.8 * nrow(data)))

--- a/src/core/test/providers/localPassages.txt
+++ b/src/core/test/providers/localPassages.txt
@@ -1,0 +1,644 @@
+:: public-austen-pride-1 | Jane Austen | Pride and Prejudice
+Elizabeth listened in silence, but was not convinced; their behavior at the assembly had not been calculated to please in general, and with more quickness of observation and less pliancy of temper than her sister, and with a judgment too unassailed by any attention to herself, she was very little disposed to approve them.
+
+:: public-dickens-cities-1 | Charles Dickens | A Tale of Two Cities
+It was the best of times, it was the worst of times, it was the age of wisdom, it was the age of foolishness, it was the epoch of belief, it was the epoch of incredulity, it was the season of Light, it was the season of Darkness.
+
+:: public-doyle-scarlet-1 | Arthur Conan Doyle | A Study in Scarlet
+There is a strong family resemblance about misdeeds, and if you have all the details of a thousand at your finger ends, it is odd if you cannot unravel the thousand and first.
+
+:: public-austen-sense-1 | Jane Austen | Sense and Sensibility
+Elinor agreed to it all, for she did not think he deserved the compliment of rational opposition. As for Marianne, on the pangs which so unhappy a meeting must already have given her, and on those still more severe which might await her in its probable consequence, she could not reflect without the deepest concern.
+
+:: public-twain-sawyer-1 | Mark Twain | The Adventures of Tom Sawyer
+The old lady pulled her spectacles down and looked over them about the room; then she put them up and looked out under them. She seldom or never looked through them for so small a thing as a boy, for they were her state pair, the pride of her heart, and were built for style, not service.
+
+:: public-montgomery-gables-1 | L. M. Montgomery | Anne of Green Gables
+Anne had no sooner seen Matthew than she dropped her carpet-bag and sprang forward. She had been waiting for him with such eager anxiety, and now that he had come she could not waste another moment in standing still.
+
+:: public-wells-time-1 | H. G. Wells | The Time Machine
+There are really four dimensions, three which we call the three planes of Space, and a fourth, Time. There is, however, a tendency to draw an unreal distinction between the former three dimensions and the latter, because it happens that our consciousness moves intermittently in one direction along the latter.
+
+:: public-alcott-women-1 | Louisa May Alcott | Little Women
+Jo's ambition was to do something very splendid; what it was she had no idea as yet, but left it for time to tell her, and meanwhile found her greatest affliction in the fact that she could not read, run, and ride as much as she liked.
+
+:: public-shelley-frankenstein-1 | Mary Shelley | Frankenstein
+Nothing is so painful to the human mind as a great and sudden change. The sun might shine, or the clouds might lower, but nothing could appear to me as it had done the day before.
+
+:: public-douglass-narrative-1 | Frederick Douglass | Narrative of the Life of Frederick Douglass
+I prefer to be true to myself, even at the hazard of incurring the ridicule of others, rather than to be false, and to incur my own abhorrence. From that time until now, I have been engaged in pleading the cause of my brethren.
+
+:: public-shakespeare-hamlet-1 | William Shakespeare | Hamlet
+This above all: to thine own self be true, and it must follow, as the night the day, thou canst not then be false to any man.
+
+:: public-franklin-almanack-1 | Benjamin Franklin | Poor Richard's Almanack
+Dost thou love life? Then do not squander time, for that is the stuff life is made of. Lost time is never found again, and one today is worth two tomorrows.
+
+:: public-emerson-self-reliance-1 | Ralph Waldo Emerson | Self-Reliance
+There is a time in every man's education when he arrives at the conviction that envy is ignorance; that imitation is suicide; that he must take himself for better, for worse, as his portion.
+
+:: public-thoreau-walden-1 | Henry David Thoreau | Walden
+I went to the woods because I wished to live deliberately, to front only the essential facts of life, and see if I could not learn what it had to teach.
+
+:: public-eliot-middlemarch-1 | George Eliot | Middlemarch
+It is a narrow mind which cannot look at a subject from various points of view. The world is full of hopeful analogies and handsome, dubious eggs, called possibilities.
+
+:: quote-001 | Aristotle | Poetics
+The greatest thing by far is to have command of metaphor, for it implies an eye for resemblances.
+
+:: quote-002 | Socrates | Plato’s Apology
+The unexamined life is not worth living, because a life without reflection cannot truly become wise.
+
+:: quote-003 | Plato | The Republic
+The beginning is the most important part of the work, especially when shaping the character of the young.
+
+:: quote-004 | Marcus Aurelius | Meditations
+You have power over your mind, not outside events; realize this, and you will find strength.
+
+:: quote-005 | Epictetus | Enchiridion
+It is not things themselves that disturb us, but the judgments we make about them.
+
+:: quote-006 | Seneca | Letters from a Stoic
+Luck is what happens when preparation meets opportunity, and wisdom is knowing how to use both.
+
+:: quote-007 | Confucius | Analects
+The person who moves a mountain begins by carrying away small stones.
+
+:: quote-008 | Laozi | Tao Te Ching
+A journey of a thousand miles begins beneath one’s feet.
+
+:: quote-009 | Buddha | Dhammapada
+Hatred is never appeased by hatred; by non-hatred alone is hatred appeased.
+
+:: quote-010 | William Shakespeare | Hamlet
+This above all: to thine own self be true, and it must follow, as night follows day.
+
+:: quote-011 | William Shakespeare | As You Like It
+The fool doth think he is wise, but the wise man knows himself to be a fool.
+
+:: quote-012 | Francis Bacon | Meditationes Sacrae
+Knowledge itself is power, but it becomes useful only when guided by judgment.
+
+:: quote-013 | Galileo Galilei | Attributed Saying
+You cannot teach a person anything; you can only help them find it within themselves.
+
+:: quote-014 | Isaac Newton | Letter to Robert Hooke
+If I have seen further, it is by standing on the shoulders of giants.
+
+:: quote-015 | Benjamin Franklin | Poor Richard’s Almanack
+Lost time is never found again, so use the present before it becomes regret.
+
+:: quote-016 | George Washington | Farewell Address
+Observe good faith and justice toward all nations; cultivate peace and harmony with all.
+
+:: quote-017 | Thomas Jefferson | Letter to Charles Yancey
+If a nation expects to be ignorant and free, it expects what never was and never will be.
+
+:: quote-018 | Abraham Lincoln | Gettysburg Address
+Government of the people, by the people, for the people, shall not perish from the earth.
+
+:: quote-019 | Frederick Douglass | West India Emancipation Speech
+If there is no struggle, there is no progress.
+
+:: quote-020 | Sojourner Truth | Ain’t I a Woman?
+If the first woman God ever made was strong enough to turn the world upside down, women together ought to turn it back.
+
+:: quote-021 | Harriet Tubman | Attributed Saying
+Every great dream begins with a dreamer, and strength comes from knowing the road to freedom.
+
+:: quote-022 | Ralph Waldo Emerson | Self-Reliance
+Trust thyself: every heart vibrates to that iron string.
+
+:: quote-023 | Henry David Thoreau | Walden
+The mass of men lead lives of quiet desperation.
+
+:: quote-024 | Walt Whitman | Song of Myself
+I am large, I contain multitudes.
+
+:: quote-025 | Emily Dickinson | Letter to T. W. Higginson
+If I feel physically as if the top of my head were taken off, I know that is poetry.
+
+:: quote-026 | Mark Twain | Following the Equator
+Truth is stranger than fiction, but it is because fiction is obliged to stick to possibilities.
+
+:: quote-027 | Oscar Wilde | Lady Windermere’s Fan
+We are all in the gutter, but some of us are looking at the stars.
+
+:: quote-028 | George Bernard Shaw | Man and Superman
+The reasonable man adapts himself to the world; the unreasonable one persists in adapting the world to himself.
+
+:: quote-029 | Helen Keller | Optimism
+Keep your face to the sunshine and you cannot see a shadow.
+
+:: quote-030 | Booker T. Washington | Up from Slavery
+Success is to be measured not by position reached, but by obstacles overcome.
+
+:: quote-031 | W. E. B. Du Bois | The Souls of Black Folk
+The problem of the twentieth century is the problem of the color line.
+
+:: quote-032 | Jane Austen | Pride and Prejudice
+Angry people are not always wise.
+
+:: quote-033 | Mary Wollstonecraft | A Vindication of the Rights of Woman
+I do not wish women to have power over men, but over themselves.
+
+:: quote-034 | Virginia Woolf | A Room of One’s Own
+One cannot think well, love well, sleep well, if one has not dined well.
+
+:: quote-035 | Charlotte Bronte | Jane Eyre
+I am no bird; and no net ensnares me.
+
+:: quote-036 | Charles Dickens | David Copperfield
+Never be mean in anything; never be false; never be cruel.
+
+:: quote-037 | Fyodor Dostoevsky | The Brothers Karamazov
+Above all, do not lie to yourself.
+
+:: quote-038 | Leo Tolstoy | Anna Karenina
+All happy families are alike; each unhappy family is unhappy in its own way.
+
+:: quote-039 | Victor Hugo | Les Miserables
+Even the darkest night will end and the sun will rise.
+
+:: quote-040 | Johann Wolfgang von Goethe | Faust
+Whatever you can do or dream you can, begin it.
+
+:: quote-041 | John Stuart Mill | On Liberty
+Over himself, over his own body and mind, the individual is sovereign.
+
+:: quote-042 | Elizabeth Cady Stanton | Declaration of Sentiments
+The history of mankind is a history of repeated injuries and usurpations on the part of man toward woman.
+
+:: quote-043 | Susan B. Anthony | Woman Wants Bread, Not the Ballot!
+Independence is happiness, and self-reliance is the beginning of freedom.
+
+:: quote-044 | Florence Nightingale | Notes on Nursing
+Wise and humane management of the patient is the best safeguard against infection.
+
+:: quote-045 | Marie Curie | Pierre Curie
+Nothing in life is to be feared; it is only to be understood.
+
+:: quote-046 | Nikola Tesla | My Inventions
+The present is theirs; the future, for which I really worked, is mine.
+
+:: quote-047 | Albert Einstein | Ideas and Opinions
+Imagination is more important than knowledge, because knowledge is limited.
+
+:: quote-048 | Mahatma Gandhi | Young India
+Be the change that you wish to see in the world.
+
+:: quote-049 | Rabindranath Tagore | Stray Birds
+You can’t cross the sea merely by standing and staring at the water.
+
+:: quote-050 | Sun Tzu | The Art of War
+In the midst of chaos, there is also opportunity.
+
+:: book-001 | Jane Austen | Pride and Prejudice
+It is a truth universally acknowledged, that a single man in possession of a good fortune, must be in want of a wife.
+
+:: book-002 | Charles Dickens | A Tale of Two Cities
+It was the best of times, it was the worst of times, it was the age of wisdom, it was the age of foolishness.
+
+:: book-003 | Herman Melville | Moby-Dick
+Call me Ishmael. Some years ago—never mind how long precisely—I thought I would sail about a little and see the watery part of the world.
+
+:: book-004 | Mary Shelley | Frankenstein
+I beheld the wretch—the miserable monster whom I had created.
+
+:: book-005 | Charlotte Bronte | Jane Eyre
+There was no possibility of taking a walk that day; the cold winter wind had brought clouds so sombre.
+
+:: book-006 | Emily Bronte | Wuthering Heights
+Whatever our souls are made of, his and mine are the same.
+
+:: book-007 | Louisa May Alcott | Little Women
+Christmas won’t be Christmas without any presents, grumbled Jo, lying on the rug.
+
+:: book-008 | Mark Twain | Adventures of Huckleberry Finn
+You don’t know about me without you have read a book by the name of The Adventures of Tom Sawyer.
+
+:: book-009 | Mark Twain | The Adventures of Tom Sawyer
+Tom appeared on the sidewalk with a bucket of whitewash and a long-handled brush.
+
+:: book-010 | L. M. Montgomery | Anne of Green Gables
+Isn’t it nice to think that tomorrow is a new day with no mistakes in it yet?
+
+:: book-011 | Lewis Carroll | Alice’s Adventures in Wonderland
+Alice was beginning to get very tired of sitting by her sister on the bank, and of having nothing to do.
+
+:: book-012 | Lewis Carroll | Through the Looking-Glass
+One thing was certain, that the white kitten had had nothing to do with it.
+
+:: book-013 | J. M. Barrie | Peter Pan
+All children, except one, grow up.
+
+:: book-014 | Frances Hodgson Burnett | The Secret Garden
+When Mary Lennox was sent to Misselthwaite Manor, everybody said she was the most disagreeable-looking child ever seen.
+
+:: book-015 | Frances Hodgson Burnett | A Little Princess
+Once on a dark winter’s day, when the yellow fog hung so thick and heavy in the streets of London.
+
+:: book-016 | Kenneth Grahame | The Wind in the Willows
+The Mole had been working very hard all the morning, spring-cleaning his little home.
+
+:: book-017 | Anna Sewell | Black Beauty
+The first place that I can well remember was a large pleasant meadow with a pond of clear water in it.
+
+:: book-018 | Robert Louis Stevenson | Treasure Island
+Squire Trelawney, Dr. Livesey, and the rest of these gentlemen asked me to write down the whole particulars.
+
+:: book-019 | Robert Louis Stevenson | Strange Case of Dr Jekyll and Mr Hyde
+Mr. Utterson the lawyer was a man of a rugged countenance, that was never lighted by a smile.
+
+:: book-020 | Daniel Defoe | Robinson Crusoe
+I was born in the year 1632, in the city of York, of a good family.
+
+:: book-021 | Jonathan Swift | Gulliver’s Travels
+My father had a small estate in Nottinghamshire; I was the third of five sons.
+
+:: book-022 | Miguel de Cervantes | Don Quixote
+In a village of La Mancha, the name of which I have no desire to call to mind, there lived a gentleman.
+
+:: book-023 | Victor Hugo | Les Miserables
+So long as ignorance and misery remain on earth, books of this kind cannot be useless.
+
+:: book-024 | Alexandre Dumas | The Count of Monte Cristo
+On the 24th of February, 1815, the look-out at Notre-Dame de la Garde signalled the three-master, the Pharaon.
+
+:: book-025 | Alexandre Dumas | The Three Musketeers
+On the first Monday of the month of April, 1625, the market town of Meung was in as perfect a state of revolution.
+
+:: book-026 | Jules Verne | Twenty Thousand Leagues Under the Seas
+The year 1866 was signalised by a remarkable incident, a mysterious and puzzling phenomenon.
+
+:: book-027 | Jules Verne | Around the World in Eighty Days
+Mr. Phileas Fogg lived, in 1872, at No. 7, Saville Row, Burlington Gardens.
+
+:: book-028 | H. G. Wells | The Time Machine
+The Time Traveller was expounding a recondite matter to us.
+
+:: book-029 | H. G. Wells | The War of the Worlds
+No one would have believed in the last years of the nineteenth century that this world was being watched keenly and closely.
+
+:: book-030 | Bram Stoker | Dracula
+Left Munich at 8:35 P.M., on 1st May, arriving at Vienna early next morning.
+
+:: book-031 | Arthur Conan Doyle | A Study in Scarlet
+In the year 1878 I took my degree of Doctor of Medicine of the University of London.
+
+:: book-032 | Arthur Conan Doyle | The Hound of the Baskervilles
+Mr. Sherlock Holmes, who was usually very late in the mornings, save upon those not infrequent occasions when he was up all night.
+
+:: book-033 | Oscar Wilde | The Picture of Dorian Gray
+The studio was filled with the rich odour of roses, and when the light summer wind stirred among the trees.
+
+:: book-034 | George Eliot | Middlemarch
+Miss Brooke had that kind of beauty which seems to be thrown into relief by poor dress.
+
+:: book-035 | George Eliot | Silas Marner
+In the days when the spinning-wheels hummed busily in the farmhouses, there might be seen pale undersized men beside the brawny country-folk.
+
+:: book-036 | Thomas Hardy | Tess of the d’Urbervilles
+On an evening in the latter part of May a middle-aged man was walking homeward from Shaston to the village of Marlott.
+
+:: book-037 | Thomas Hardy | Far from the Madding Crowd
+When Farmer Oak smiled, the corners of his mouth spread till they were within an unimportant distance of his ears.
+
+:: book-038 | Nathaniel Hawthorne | The Scarlet Letter
+A throng of bearded men, in sad-colored garments and gray steeple-crowned hats, was assembled in front of a wooden edifice.
+
+:: book-039 | Nathaniel Hawthorne | The House of the Seven Gables
+Halfway down a by-street of one of our New England towns stands a rusty wooden house.
+
+:: book-040 | Fyodor Dostoevsky | Crime and Punishment
+On an exceptionally hot evening early in July a young man came out of the garret in which he lodged.
+
+:: book-041 | Fyodor Dostoevsky | The Brothers Karamazov
+Alexey Fyodorovich Karamazov was the third son of Fyodor Pavlovich Karamazov, a landowner well known in our district.
+
+:: book-042 | Leo Tolstoy | War and Peace
+Well, Prince, so Genoa and Lucca are now just family estates of the Buonapartes.
+
+:: book-043 | Leo Tolstoy | Anna Karenina
+All happy families are alike; each unhappy family is unhappy in its own way.
+
+:: book-044 | Edith Wharton | The Age of Innocence
+On a January evening of the early seventies, Christine Nilsson was singing in Faust at the Academy of Music in New York.
+
+:: book-045 | Edith Wharton | Ethan Frome
+I had the story, bit by bit, from various people, and, as generally happens in such cases, each time it was a different story.
+
+:: book-046 | Willa Cather | My Antonia
+I first heard of Antonia on what seemed to me an interminable journey across the great midland plain of North America.
+
+:: book-047 | Willa Cather | O Pioneers!
+One January day, thirty years ago, the little town of Hanover, anchored on a windy Nebraska tableland, was trying not to be blown away.
+
+:: book-048 | Jack London | The Call of the Wild
+Buck did not read the newspapers, or he would have known that trouble was brewing.
+
+:: book-049 | Jack London | White Fang
+Dark spruce forest frowned on either side the frozen waterway.
+
+:: book-050 | Joseph Conrad | Heart of Darkness
+The Nellie, a cruising yawl, swung to her anchor without a flutter of the sails, and was at rest.
+
+:: book-001 | Jane Austen | Pride and Prejudice
+The world of manners, marriage, reputation, and first impressions becomes a place where people constantly misread one another. Beneath polite conversation, characters reveal pride, insecurity, wit, longing, and the slow education of judgment.
+
+:: book-002 | Charles Dickens | A Tale of Two Cities
+The novel opens in a world divided by extremes, where hope and despair exist side by side. Its atmosphere suggests that history moves through contradiction, with private lives caught inside public violence and revolution.
+
+:: book-003 | Herman Melville | Moby-Dick
+The narrator turns toward the sea not simply for adventure, but because restlessness has gathered inside him. The ocean becomes a place of escape, mystery, danger, and confrontation with forces larger than human certainty.
+
+:: book-004 | Mary Shelley | Frankenstein
+The creator looks upon what he has made and discovers that ambition without responsibility can become horror. Scientific achievement, separated from compassion, leaves both maker and creation abandoned in fear and suffering.
+
+:: book-005 | Charlotte Bronte | Jane Eyre
+Jane’s story begins in loneliness and restraint, but her inner life refuses to shrink. She learns to value love deeply while still protecting the independence, conscience, and dignity that define her.
+
+:: book-006 | Emily Bronte | Wuthering Heights
+The landscape of the moors mirrors the emotional violence of the people who inhabit it. Love, resentment, pride, and revenge become tangled until affection itself seems inseparable from pain and destruction.
+
+:: book-007 | Louisa May Alcott | Little Women
+The March sisters live with limited money but rich emotional lives, learning that growing up means balancing dreams, duty, love, disappointment, and ambition. Their home becomes a place of warmth and moral testing.
+
+:: book-008 | Mark Twain | Adventures of Huckleberry Finn
+Huck’s journey down the river becomes more than an escape from rules and violence. It becomes a moral education, forcing him to choose between what society teaches and what conscience quietly knows.
+
+:: book-009 | Mark Twain | The Adventures of Tom Sawyer
+Tom turns ordinary childhood into performance, mischief, and adventure. Through games, schemes, and imagination, the novel captures how children transform small-town life into a stage for freedom, risk, and discovery.
+
+:: book-010 | L. M. Montgomery | Anne of Green Gables
+Anne arrives unwanted by mistake, yet quickly fills Green Gables with imagination, emotion, and dramatic language. Her longing to belong gives the story its tenderness, humour, and enduring sense of hope.
+
+:: book-011 | Lewis Carroll | Alice’s Adventures in Wonderland
+Alice enters a world where ordinary logic collapses, language misbehaves, and identity becomes uncertain. The strange conversations and impossible events make childhood curiosity feel both delightful and deeply unsettling.
+
+:: book-012 | Lewis Carroll | Through the Looking-Glass
+The looking-glass world reverses expectations, turning reality into a puzzle of chess, riddles, and absurd rules. Alice must navigate a place where meaning shifts just when she thinks she understands it.
+
+:: book-013 | J. M. Barrie | Peter Pan
+The story imagines childhood as magical, rebellious, and fleeting, but also shadowed by loss. Neverland offers freedom from adulthood, yet its wonder depends on refusing the responsibilities that make love lasting.
+
+:: book-014 | Frances Hodgson Burnett | The Secret Garden
+Mary begins as a neglected, disagreeable child, but the hidden garden slowly changes her. As the earth revives, so does her capacity for friendship, wonder, health, and emotional connection.
+
+:: book-015 | Frances Hodgson Burnett | A Little Princess
+Sara’s dignity is tested when comfort and privilege disappear. Even in poverty and humiliation, she clings to imagination, kindness, and inner nobility, showing that character is not dependent on wealth.
+
+:: book-016 | Kenneth Grahame | The Wind in the Willows
+The riverbank world feels gentle, companionable, and full of small adventures. Mole, Rat, Badger, and Toad each represent different temperaments, reminding readers that friendship must make room for difference.
+
+:: book-017 | Anna Sewell | Black Beauty
+The story gives a horse a voice in order to expose human cruelty and kindness. Through Black Beauty’s experiences, the novel asks readers to consider responsibility toward animals with moral seriousness.
+
+:: book-018 | Robert Louis Stevenson | Treasure Island
+The search for treasure promises excitement, but it also brings danger, betrayal, and moral testing. Jim Hawkins enters adventure as a boy and learns that courage often appears before certainty does.
+
+:: book-019 | Robert Louis Stevenson | Strange Case of Dr Jekyll and Mr Hyde
+The mystery of Jekyll and Hyde reveals a frightening division within human nature. Respectability hides impulses that, once separated from conscience, grow monstrous and threaten to consume the whole person.
+
+:: book-020 | Daniel Defoe | Robinson Crusoe
+Crusoe’s isolation forces him to rebuild life from fragments of survival, memory, labour, and faith. The island becomes both prison and classroom, teaching him discipline, fear, gratitude, and self-reliance.
+
+:: book-021 | Jonathan Swift | Gulliver’s Travels
+Gulliver’s voyages appear fantastical, yet each strange society reflects human foolishness in distorted form. By making the familiar look absurd, Swift exposes pride, politics, cruelty, and the limits of reason.
+
+:: book-022 | Miguel de Cervantes | Don Quixote
+Don Quixote sees the world not as it is, but as his imagination insists it must be. His madness is comic, yet it also reveals the beauty and danger of idealism.
+
+:: book-023 | Victor Hugo | Les Miserables
+The novel follows suffering through prisons, streets, barricades, and homes, insisting that social injustice is never abstract. Mercy becomes a force capable of transforming lives where law alone has failed.
+
+:: book-024 | Alexandre Dumas | The Count of Monte Cristo
+Betrayal sends Edmond Dantes into darkness, but patience turns his suffering into a long and intricate revenge. The story asks whether justice remains pure when it is carried out through vengeance.
+
+:: book-025 | Alexandre Dumas | The Three Musketeers
+Friendship, honour, romance, and political intrigue drive the world of the musketeers. Their famous loyalty is not passive affection, but a shared willingness to face danger together with style and courage.
+
+:: book-026 | Jules Verne | Twenty Thousand Leagues Under the Seas
+The sea becomes a vast unknown world filled with beauty, science, terror, and secrecy. Captain Nemo’s submarine offers freedom from ordinary society, but also reveals isolation and unresolved bitterness.
+
+:: book-027 | Jules Verne | Around the World in Eighty Days
+Phileas Fogg treats time as something measurable, disciplined, and exact, yet his journey around the world becomes unpredictable. The adventure tests whether order can survive chance, delay, and human attachment.
+
+:: book-028 | H. G. Wells | The Time Machine
+The invention of time travel allows the future to become a warning rather than a fantasy. Wells imagines social inequality stretched across centuries until humanity itself appears divided and diminished.
+
+:: book-029 | H. G. Wells | The War of the Worlds
+The invasion unsettles human confidence by making Earth vulnerable to a superior force. Ordinary life collapses quickly, and the novel shows how fragile civilization becomes when its assumptions are overturned.
+
+:: book-030 | Bram Stoker | Dracula
+The novel builds fear through letters, diaries, travel notes, and fragments of testimony. Dracula’s presence threatens bodies, homes, faith, and modern certainty, turning invasion into both horror and symbolism.
+
+:: book-031 | Arthur Conan Doyle | A Study in Scarlet
+Sherlock Holmes enters the story as a figure of sharp observation, strange habits, and remarkable deduction. The ordinary world becomes readable to him because he notices what others dismiss as meaningless.
+
+:: book-032 | Arthur Conan Doyle | The Hound of the Baskervilles
+The moor creates an atmosphere of superstition, danger, and isolation. Holmes and Watson must separate legend from evidence, showing how fear can cloud reason until careful observation restores clarity.
+
+:: book-033 | Oscar Wilde | The Picture of Dorian Gray
+Dorian’s beauty becomes a shield from consequence, while his hidden portrait records what society cannot see. The novel turns aesthetic pleasure into a moral question about corruption, vanity, and secrecy.
+
+:: book-034 | George Eliot | Middlemarch
+Middlemarch explores ambition, marriage, disappointment, and moral growth within an ordinary provincial community. Its characters are not simply heroes or villains, but people shaped by choices, limitations, and misunderstood desires.
+
+:: book-035 | George Eliot | Silas Marner
+Silas begins in isolation, wounded by betrayal and living through mechanical labour and hoarded gold. His life changes when unexpected love enters quietly, replacing loss with human attachment and renewed purpose.
+
+:: book-036 | Thomas Hardy | Tess of the d’Urbervilles
+Tess moves through a world that judges her harshly while failing to protect her innocence. Hardy presents her tragedy as both personal suffering and an indictment of social hypocrisy.
+
+:: book-037 | Thomas Hardy | Far from the Madding Crowd
+Bathsheba Everdene’s independence attracts admiration, desire, and conflict. Around her, love appears in different forms: patient devotion, reckless passion, possessive pride, and the difficult wisdom gained through consequence.
+
+:: book-038 | Nathaniel Hawthorne | The Scarlet Letter
+Hester’s punishment is meant to expose shame, yet it also reveals the cruelty of public judgment. The scarlet letter becomes both a mark of condemnation and a symbol she transforms.
+
+:: book-039 | Nathaniel Hawthorne | The House of the Seven Gables
+The old house carries the weight of ancestral guilt, secrecy, and decay. Hawthorne turns architecture into memory, showing how the past can live inside walls, families, and inherited shame.
+
+:: book-040 | Fyodor Dostoevsky | Crime and Punishment
+Raskolnikov’s crime begins as an idea, but the reality of guilt destroys his theories. The novel follows a mind trapped between pride, suffering, confession, and the possibility of redemption.
+
+:: book-041 | Fyodor Dostoevsky | The Brothers Karamazov
+The Karamazov family becomes a battlefield of faith, doubt, sensuality, resentment, and moral responsibility. Through their conflicts, the novel asks whether love and belief can survive human cruelty.
+
+:: book-042 | Leo Tolstoy | War and Peace
+Tolstoy places private lives against the vast movement of history, refusing to treat war as simple glory. Families, soldiers, and rulers all become part of forces larger than individual intention.
+
+:: book-043 | Leo Tolstoy | Anna Karenina
+Anna’s story unfolds within a society obsessed with appearances, duty, and reputation. Her search for love becomes inseparable from judgment, isolation, passion, and the costs of violating social expectation.
+
+:: book-044 | Edith Wharton | The Age of Innocence
+Old New York society appears elegant and controlled, but its rules quietly govern desire, marriage, and belonging. The novel shows how politeness can become a beautiful form of imprisonment.
+
+:: book-045 | Edith Wharton | Ethan Frome
+The cold landscape reflects Ethan’s emotional confinement, poverty, and regret. His life feels trapped between duty and longing, making the novel’s quiet tragedy feel as severe as winter itself.
+
+:: book-046 | Willa Cather | My Antonia
+The prairie becomes a place of memory, hardship, and beauty. Antonia represents resilience and immigrant strength, while the narrator looks back with tenderness at youth, landscape, and lost time.
+
+:: book-047 | Willa Cather | O Pioneers!
+The novel follows settlers who try to make a future from difficult land. Alexandra’s strength lies in seeing possibility where others see only hardship, debt, loneliness, and uncertainty.
+
+:: book-048 | Jack London | The Call of the Wild
+Buck is pulled from domestic comfort into a brutal world where instinct returns. The story traces his transformation from pet to survivor, shaped by violence, loyalty, memory, and the wilderness.
+
+:: book-049 | Jack London | White Fang
+White Fang’s life begins in hunger, cold, fear, and struggle, but the story gradually asks whether brutality is destiny. Trust becomes possible only when kindness proves stronger than cruelty.
+
+:: book-050 | Joseph Conrad | Heart of Darkness
+The journey into the interior becomes a journey into moral darkness, empire, and human corruption. Conrad’s river carries the narrator away from certainty and toward a disturbing recognition of civilization’s fragility.
+
+:: quote-001 | Aristotle | Nicomachean Ethics
+Excellence is not something we become in a single moment, but something shaped through repeated action, disciplined choices, and the habits we practice when no one is watching. Character is built slowly, through what we continue to do.
+
+:: quote-002 | Socrates | Apology
+A life that is never examined becomes easy to live on the surface, but difficult to understand in truth. To question ourselves is not weakness; it is the beginning of wisdom, humility, and moral courage.
+
+:: quote-003 | Plato | The Republic
+The education of a person begins long before they understand its importance, because the stories, examples, and values placed before the young quietly shape what they later believe to be good, just, and possible.
+
+:: quote-004 | Confucius | Analects
+Learning is not only about gathering knowledge, but about returning to what we have learned and practicing it with sincerity. A person becomes wise by reflecting, correcting themselves, and acting with care toward others.
+
+:: quote-005 | Laozi | Tao Te Ching
+Great things often begin quietly, without force or announcement. The longest journey still begins with one step, and the strongest tree still grows from something small, patient, rooted, and easily overlooked.
+
+:: quote-006 | Marcus Aurelius | Meditations
+You may not control what happens around you, but you can choose the judgment you place upon it. Peace begins when the mind stops surrendering its strength to every outside event.
+
+:: quote-007 | Epictetus | Enchiridion
+Freedom does not come from controlling the world, because the world will always resist control. True freedom begins when a person learns to govern their own desires, reactions, fears, and expectations.
+
+:: quote-008 | Seneca | Letters from a Stoic
+Time is the one possession people waste most carelessly, even though it cannot be recovered once lost. A wise person treats each day as something borrowed, precious, and worthy of intentional use.
+
+:: quote-009 | Cicero | On Duties
+Justice is not simply a law written by others, but a responsibility carried within the character of each person. A good society depends on people choosing fairness even when selfishness would be easier.
+
+:: quote-010 | Buddha | Dhammapada
+Hatred does not end by answering it with more hatred, because anger only feeds the fire it claims to defeat. Peace begins when compassion interrupts the cycle and refuses to pass suffering onward.
+
+:: quote-011 | Jesus | Sermon on the Mount
+The measure of a life is not found only in outward appearance, public praise, or visible success, but in the condition of the heart and the mercy one shows when no reward is expected.
+
+:: quote-012 | Muhammad | Hadith Tradition
+The strongest person is not the one who can overpower others, but the one who can restrain themselves when anger rises. Self-control is a quieter strength, but often the more difficult victory.
+
+:: quote-013 | Rumi | Masnavi
+The wound is not always the end of something; sometimes it is the place where understanding begins. Pain can open a door in the heart that comfort never knew how to find.
+
+:: quote-014 | William Shakespeare | Hamlet
+A person may deceive the world with language, appearance, and performance, but the self remains difficult to escape. To be honest with oneself is the foundation from which all other honesty grows.
+
+:: quote-015 | Francis Bacon | Of Studies
+Reading gives the mind material, conversation gives it movement, and writing gives it precision. Knowledge becomes most useful when it is not merely collected, but tested, organized, and applied with judgment.
+
+:: quote-016 | Galileo Galilei | Letter to the Grand Duchess Christina
+Truth does not become false simply because it is difficult to accept, nor does inquiry become dangerous because it challenges old assumptions. The honest search for understanding requires courage, patience, and humility.
+
+:: quote-017 | Isaac Newton | Letter to Robert Hooke
+No discovery belongs only to one person, because every thinker stands upon the work, questions, and struggles of those who came before. Progress is often less a solitary leap than a shared ascent.
+
+:: quote-018 | Benjamin Franklin | Poor Richard’s Almanack
+Time, once wasted, does not return with regret. A person who delays every useful action until tomorrow may eventually find that tomorrow has become a place where opportunity no longer waits.
+
+:: quote-019 | George Washington | Farewell Address
+Public trust is fragile, and a nation depends on citizens who value unity, responsibility, and restraint. Liberty cannot survive on passion alone; it requires character, wisdom, and a willingness to serve something larger than self.
+
+:: quote-020 | Thomas Jefferson | Declaration of Independence
+Human dignity rests on the belief that people are not born to be ruled as property, silenced as subjects, or denied the rights of conscience, liberty, and participation in shaping their collective future.
+
+:: quote-021 | Thomas Paine | Common Sense
+A long habit of accepting wrong can make injustice appear natural, but familiarity does not make oppression right. When people begin to question inherited power, they also begin to imagine freedom differently.
+
+:: quote-022 | Abraham Lincoln | Gettysburg Address
+A nation dedicated to liberty must constantly prove that its ideals are more than words. The living are responsible for carrying forward the unfinished work of justice, sacrifice, and democratic purpose.
+
+:: quote-023 | Frederick Douglass | West India Emancipation Speech
+Progress does not arrive because people simply wish for it, nor because power becomes generous on its own. Every movement toward freedom requires struggle, pressure, sacrifice, and the refusal to accept injustice as permanent.
+
+:: quote-024 | Sojourner Truth | Ain’t I a Woman?
+Strength is not limited to the people society chooses to recognize. Those who have labored, suffered, endured, and still spoken with courage reveal a power that prejudice tries, but fails, to erase.
+
+:: quote-025 | Harriet Tubman | Reflections on Freedom
+Freedom requires more than escaping chains; it requires believing that another life is possible. Courage is not the absence of fear, but the decision to move forward while fear walks beside you.
+
+:: quote-026 | Elizabeth Cady Stanton | Declaration of Sentiments
+Equality cannot be partial and still be called justice. When laws, customs, and institutions deny women full personhood, the demand for rights becomes not rebellion, but a necessary correction of society.
+
+:: quote-027 | Susan B. Anthony | Speech After Arrest for Voting
+Citizenship loses its meaning when half the people are governed without equal voice. Justice requires that rights belong not only to those already powerful, but to every person subject to the law.
+
+:: quote-028 | Mary Wollstonecraft | A Vindication of the Rights of Woman
+Women should not be educated merely to please others, but to strengthen their own reason, judgment, and independence. A society that weakens women’s minds cannot honestly claim to value virtue or progress.
+
+:: quote-029 | Florence Nightingale | Notes on Nursing
+Care is not only kindness, but close observation, discipline, cleanliness, and attention to conditions that allow healing. The environment surrounding a patient can either support recovery or quietly work against it.
+
+:: quote-030 | Charles Darwin | On the Origin of Species
+Nature is not fixed in perfect stillness, but shaped through variation, pressure, survival, and time. Small differences, accumulated across generations, can alter the living world in ways no single moment reveals.
+
+:: quote-031 | Marie Curie | Reflections on Science
+Fear often grows where understanding is absent. The task of science is not to remove wonder from life, but to replace helpless fear with careful knowledge, patient investigation, and respect for truth.
+
+:: quote-032 | Nikola Tesla | My Inventions
+The future belongs not only to those who inherit the present, but to those willing to imagine what does not yet exist. Invention begins where dissatisfaction meets disciplined vision.
+
+:: quote-033 | Albert Einstein | Ideas and Opinions
+Imagination allows the mind to move beyond what is already known, while knowledge gives that movement structure. Both are needed, because discovery requires facts, curiosity, and the courage to ask impossible questions.
+
+:: quote-034 | Helen Keller | Optimism
+Optimism is not pretending that hardship does not exist, but believing that hardship is not the whole story. Hope gives people the strength to act when despair would prefer them to stop.
+
+:: quote-035 | Booker T. Washington | Up from Slavery
+Success should not be measured only by the height someone reaches, but by the obstacles they had to overcome on the way. Effort, dignity, and perseverance reveal more than position alone.
+
+:: quote-036 | W. E. B. Du Bois | The Souls of Black Folk
+To live behind a veil is to understand a society that sees you incompletely. The struggle is not only for opportunity, but for recognition, dignity, and the right to be fully human.
+
+:: quote-037 | Jane Austen | Pride and Prejudice
+Pride may protect a person’s dignity, but it can also blind them to their own faults. Wisdom requires learning when judgment is clear and when it has been quietly distorted by vanity.
+
+:: quote-038 | Charles Dickens | David Copperfield
+Kindness, honesty, and tenderness are not small virtues simply because they appear ordinary. A person’s moral life is often revealed in daily conduct, especially toward those with less power.
+
+:: quote-039 | Charlotte Bronte | Jane Eyre
+Independence does not mean a heart without feeling; it means refusing to surrender one’s conscience, dignity, or self-respect for comfort, approval, or love that asks too much in return.
+
+:: quote-040 | Emily Dickinson | Letters
+The mind can travel farther than the body, and poetry can open rooms that ordinary speech leaves locked. A few carefully chosen words may hold more feeling than an entire conversation.
+
+:: quote-041 | Walt Whitman | Leaves of Grass
+A person is never only one thing, but a gathering of contradictions, memories, desires, and possibilities. To contain multitudes is not confusion; it is part of being fully alive.
+
+:: quote-042 | Ralph Waldo Emerson | Self-Reliance
+To trust oneself is difficult because society rewards imitation and punishes difference. Yet every original life begins when a person stops asking permission to become what conscience already knows.
+
+:: quote-043 | Henry David Thoreau | Walden
+A person may live surrounded by possessions and still feel poor in spirit. Simplicity asks us to notice what is truly necessary, and to stop mistaking accumulation for meaning.
+
+:: quote-044 | Mark Twain | Following the Equator
+Truth often appears stranger than fiction because reality does not need to be believable. Fiction must obey possibility, but life moves with a wildness that no storyteller would always dare invent.
+
+:: quote-045 | Oscar Wilde | The Picture of Dorian Gray
+Beauty can attract admiration, but it cannot substitute for conscience. A life devoted only to appearance eventually reveals the emptiness beneath the surface it worked so carefully to preserve.
+
+:: quote-046 | George Bernard Shaw | Man and Superman
+Progress often depends on people unreasonable enough to question what everyone else has accepted. The world changes because someone refuses to treat present limits as permanent laws.
+
+:: quote-047 | Victor Hugo | Les Miserables
+Even the darkest night is not eternal, because human suffering is never the final word. Hope survives in the smallest acts of mercy, courage, and love offered against despair.
+
+:: quote-048 | Leo Tolstoy | Anna Karenina
+Happiness may look simple from the outside, but unhappiness has its own particular history. Every family carries private wounds, hidden conflicts, and stories that cannot be understood from appearances alone.
+
+:: quote-049 | Fyodor Dostoevsky | The Brothers Karamazov
+To lie to others is harmful, but to lie to oneself is spiritually destructive. A person who refuses self-honesty slowly loses the ability to recognize truth anywhere else.
+
+:: quote-050 | Sun Tzu | The Art of War
+The greatest victory is not always the loudest battle, but the outcome shaped before conflict fully begins. Strategy requires knowing oneself, understanding the opponent, and acting with patience rather than impulse.

--- a/src/core/test/providers/quoteProvider.ts
+++ b/src/core/test/providers/quoteProvider.ts
@@ -1,0 +1,261 @@
+import { getLS, setLS } from "../../storage/localStorage";
+import localPassages from "./localPassages.txt?raw";
+
+export type QuoteSourceType = "api" | "cache" | "local";
+
+export type NormalizedQuote = {
+  text: string;
+  author: string;
+  source: string;
+  id: string;
+};
+
+export type QuoteFetchResult = {
+  quote: NormalizedQuote;
+  sourceType: QuoteSourceType;
+  failureReason?: string;
+};
+
+type QuoteProviderName = "ZenQuotes";
+
+export type QuoteProviderOptions = {
+  timeoutMs: number;
+  retries: number;
+  minLength: number;
+  maxLength: number;
+  fetchImpl: typeof fetch;
+  preferLocal: boolean;
+  endpoints: Partial<Record<QuoteProviderName, string>>;
+};
+
+type QuoteProvider = {
+  source: QuoteProviderName;
+  endpoint: string;
+  normalize(payload: unknown, maxLength: number): NormalizedQuote | null;
+};
+
+const QUOTE_CACHE_KEY = "kt_quote_cache";
+const DEFAULT_OPTIONS: QuoteProviderOptions = {
+  timeoutMs: 1600,
+  retries: 1,
+  minLength: 24,
+  maxLength: 900,
+  fetchImpl: (...args) => fetch(...args),
+  preferLocal: true,
+  endpoints: {},
+};
+
+const PROVIDERS: QuoteProvider[] = [
+  {
+    source: "ZenQuotes",
+    endpoint: "https://zenquotes.io/api/random",
+    normalize(payload, maxLength) {
+      const [item] = Array.isArray(payload) ? payload : [];
+      const quote = item as { q?: unknown; a?: unknown; h?: unknown } | undefined;
+      return normalizeQuote({
+        text: quote?.q,
+        author: quote?.a,
+        source: "ZenQuotes",
+        id: quote?.h,
+        maxLength,
+      });
+    },
+  },
+];
+
+function sanitizeText(value: unknown): string {
+  if (typeof value !== "string") return "";
+
+  return value
+    .normalize("NFKC")
+    .replace(/[\u0000-\u001f\u007f]/g, " ")
+    .replace(/[<>]/g, "")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+function sanitizeId(value: unknown): string {
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return String(value);
+  }
+
+  return sanitizeText(value);
+}
+
+function normalizeQuote(input: {
+  text: unknown;
+  author: unknown;
+  source: string;
+  id: unknown;
+  maxLength: number;
+}): NormalizedQuote | null {
+  const text = sanitizeText(input.text);
+  if (!text || text.length > input.maxLength) return null;
+
+  const author = sanitizeText(input.author) || "Unknown";
+  const id = sanitizeId(input.id) || `${input.source}:${text.slice(0, 32)}`;
+
+  return {
+    text,
+    author,
+    source: input.source,
+    id,
+  };
+}
+
+function isQuote(value: unknown): value is NormalizedQuote {
+  const quote = value as Partial<NormalizedQuote>;
+  return (
+    typeof quote?.text === "string" &&
+    quote.text.length > 0 &&
+    typeof quote.author === "string" &&
+    typeof quote.source === "string" &&
+    typeof quote.id === "string"
+  );
+}
+
+function getCachedQuote(maxLength: number): NormalizedQuote | null {
+  const quote = getLS<NormalizedQuote | null>(QUOTE_CACHE_KEY, null);
+  if (!isQuote(quote)) return null;
+
+  return normalizeQuote({
+    text: quote.text,
+    author: quote.author,
+    source: quote.source,
+    id: quote.id,
+    maxLength,
+  });
+}
+
+function cacheQuote(quote: NormalizedQuote): void {
+  setLS(QUOTE_CACHE_KEY, quote);
+}
+
+export function getLocalQuotes(maxLength = DEFAULT_OPTIONS.maxLength): NormalizedQuote[] {
+  return parseLocalPassages(localPassages)
+    .map((quote) =>
+      normalizeQuote({
+        ...quote,
+        source: quote.source ?? "Local Passages",
+        maxLength,
+      })
+    )
+    .filter(isQuote);
+}
+
+function parseLocalPassages(raw: string): Array<{ id: string; text: string; author: string; source: string }> {
+  return raw
+    .split(/\n(?=:: )/g)
+    .map((block) => {
+      const [header = "", ...bodyLines] = block.trim().split("\n");
+      const match = header.match(/^::\s*([^|]+)\|\s*([^|]+)\|\s*(.+)$/);
+      if (!match) return null;
+
+      return {
+        id: match[1].trim(),
+        author: match[2].trim(),
+        source: match[3].trim(),
+        text: bodyLines.join(" ").trim(),
+      };
+    })
+    .filter((quote): quote is { id: string; text: string; author: string; source: string } => quote !== null);
+}
+
+export function getRandomLocalQuote(maxLength = DEFAULT_OPTIONS.maxLength): NormalizedQuote {
+  const quotes = getLocalQuotes(maxLength);
+  return quotes[Math.floor(Math.random() * quotes.length)];
+}
+
+async function fetchJsonWithTimeout(
+  endpoint: string,
+  timeoutMs: number,
+  fetchImpl: typeof fetch
+): Promise<unknown> {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), timeoutMs);
+
+  try {
+    const response = await fetchImpl(endpoint, {
+      signal: controller.signal,
+      headers: { Accept: "application/json" },
+    });
+
+    if (!response.ok) {
+      throw new Error(`HTTP ${response.status}`);
+    }
+
+    return await response.json();
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+async function fetchFromProvider(
+  provider: QuoteProvider,
+  endpoint: string,
+  options: QuoteProviderOptions
+): Promise<NormalizedQuote> {
+  let lastError: unknown = null;
+
+  for (let attempt = 0; attempt <= options.retries; attempt += 1) {
+    try {
+      const payload = await fetchJsonWithTimeout(endpoint, options.timeoutMs, options.fetchImpl);
+      const quote = provider.normalize(payload, options.maxLength);
+      if (!quote || quote.text.length < options.minLength) {
+        throw new Error(`${provider.source} returned no usable quote.`);
+      }
+      return quote;
+    } catch (error) {
+      lastError = error;
+    }
+  }
+
+  throw lastError instanceof Error ? lastError : new Error(`${provider.source} request failed.`);
+}
+
+function failureMessage(provider: string, error: unknown): string {
+  const message = error instanceof Error ? error.message : "request failed";
+  return `${provider}: ${message}`;
+}
+
+export async function fetchQuote(
+  partialOptions: Partial<QuoteProviderOptions> = {}
+): Promise<QuoteFetchResult> {
+  const options = { ...DEFAULT_OPTIONS, ...partialOptions };
+  const failures: string[] = [];
+  const localQuote = getRandomLocalQuote(options.maxLength);
+
+  if (options.preferLocal) {
+    return {
+      quote: localQuote,
+      sourceType: "local",
+    };
+  }
+
+  for (const provider of PROVIDERS) {
+    try {
+      const endpoint = options.endpoints[provider.source] ?? provider.endpoint;
+      const quote = await fetchFromProvider(provider, endpoint, options);
+      cacheQuote(quote);
+      return { quote, sourceType: "api" };
+    } catch (error) {
+      failures.push(failureMessage(provider.source, error));
+    }
+  }
+
+  const failureReason = failures.join(" | ");
+  const cachedQuote = getCachedQuote(options.maxLength);
+  if (cachedQuote && cachedQuote.text.length >= options.minLength) {
+    return {
+      quote: cachedQuote,
+      sourceType: "cache",
+      failureReason,
+    };
+  }
+
+  return {
+    quote: localQuote,
+    sourceType: "local",
+    failureReason,
+  };
+}

--- a/src/core/test/quotesGenerator.ts
+++ b/src/core/test/quotesGenerator.ts
@@ -1,0 +1,50 @@
+import { getRandomLocalQuote, type NormalizedQuote } from "./providers/quoteProvider";
+import type { QuotesGeneratorOptions, TestGenerator } from "./types";
+
+function formatQuote(quote: NormalizedQuote): string {
+  return `${quote.text} ${quote.author}`;
+}
+
+function buildQuoteText(seedQuote: NormalizedQuote): string {
+  return formatQuote(seedQuote);
+}
+
+export const quotesGenerator: TestGenerator<QuotesGeneratorOptions> = {
+  validateOptions(options) {
+    if (typeof options.includePunctuation !== "boolean") {
+      return { valid: false, reason: "Quotes generator requires includePunctuation to be a boolean." };
+    }
+
+    if (typeof options.includeNumbers !== "boolean") {
+      return { valid: false, reason: "Quotes generator requires includeNumbers to be a boolean." };
+    }
+
+    if (typeof options.randomCase !== "boolean") {
+      return { valid: false, reason: "Quotes generator requires randomCase to be a boolean." };
+    }
+
+    if (options.quote != null && typeof options.quote.text !== "string") {
+      return { valid: false, reason: "Quotes generator requires quote text when a quote is provided." };
+    }
+
+    return {
+      valid: true,
+      options: {
+        includePunctuation: options.includePunctuation,
+        includeNumbers: options.includeNumbers,
+        randomCase: false,
+        quote: options.quote,
+      },
+    };
+  },
+
+  generateInitialText({ durationSeconds, options }) {
+    void durationSeconds;
+    return buildQuoteText(options.quote ?? getRandomLocalQuote());
+  },
+
+  generateChunk({ wordCount, options }) {
+    void wordCount;
+    return buildQuoteText(getRandomLocalQuote());
+  },
+};

--- a/src/core/test/registry.ts
+++ b/src/core/test/registry.ts
@@ -1,5 +1,7 @@
 import { adaptiveWeakLetterGenerator } from "./adaptiveWeakLetterGenerator";
 import { classicWordsGenerator } from "./classicWordsGenerator";
+import { codeSnippetGenerator } from "./codeSnippetGenerator";
+import { quotesGenerator } from "./quotesGenerator";
 import type { TestGenerator, TestMode, TestModeOptionsMap } from "./types";
 
 export const TEST_GENERATORS: {
@@ -7,6 +9,8 @@ export const TEST_GENERATORS: {
 } = {
   standard: classicWordsGenerator,
   adaptive: adaptiveWeakLetterGenerator,
+  quotes: quotesGenerator,
+  code: codeSnippetGenerator,
 };
 
 export function getTestGenerator<M extends TestMode>(

--- a/src/core/test/testGenerators.test.ts
+++ b/src/core/test/testGenerators.test.ts
@@ -1,8 +1,12 @@
 import { describe, expect, it, vi, afterEach } from "vitest";
 import { classicWordsGenerator } from "./classicWordsGenerator";
 import { adaptiveWeakLetterGenerator } from "./adaptiveWeakLetterGenerator";
+import { codeSnippetGenerator } from "./codeSnippetGenerator";
+import { quotesGenerator } from "./quotesGenerator";
 import { TEST_GENERATORS } from "./registry";
 import { applyRandomCase } from "./generatorUtils";
+import { getRandomLocalCodeSnippet } from "./providers/codeSnippetProvider";
+import { fetchQuote } from "./providers/quoteProvider";
 
 describe("test generators", () => {
   afterEach(() => {
@@ -118,5 +122,114 @@ describe("test generators", () => {
   it("registry contains standard and adaptive modes", () => {
     expect(TEST_GENERATORS.standard).toBe(classicWordsGenerator);
     expect(TEST_GENERATORS.adaptive).toBe(adaptiveWeakLetterGenerator);
+    expect(TEST_GENERATORS.quotes).toBe(quotesGenerator);
+    expect(TEST_GENERATORS.code).toBe(codeSnippetGenerator);
+  });
+
+  it("quotes generator keeps natural sentence punctuation from quote text", () => {
+    const text = quotesGenerator.generateInitialText({
+      durationSeconds: 15,
+      options: {
+        includePunctuation: true,
+        includeNumbers: true,
+        randomCase: false,
+        quote: {
+          id: "test-quote",
+          text: "Practice should feel like real writing, not only word lists.",
+          author: "Test Author",
+          source: "Test",
+        },
+      },
+    });
+
+    expect(text).toContain("Practice should feel like real writing, not only word lists. Test Author");
+    expect(text).toBe("Practice should feel like real writing, not only word lists. Test Author");
+  });
+
+  it("quotes generator preserves quote capitalization even if random case is enabled", () => {
+    const text = quotesGenerator.generateInitialText({
+      durationSeconds: 15,
+      options: {
+        includePunctuation: true,
+        includeNumbers: true,
+        randomCase: true,
+        quote: {
+          id: "case-test",
+          text: "This sentence should not become Title Case.",
+          author: "Case Author",
+          source: "Test",
+        },
+      },
+    });
+
+    expect(text).toContain("This sentence should not become Title Case. Case Author");
+    expect(text).not.toContain("This Sentence Should Not Become Title Case");
+  });
+
+  it("quote provider pulls from bundled local passages by default", async () => {
+    const result = await fetchQuote({
+      retries: 0,
+      timeoutMs: 1,
+      fetchImpl: vi.fn().mockRejectedValue(new Error("offline")),
+    });
+
+    expect(result.sourceType).toBe("local");
+    expect(result.failureReason).toBeUndefined();
+    expect(result.quote.text.length).toBeGreaterThan(0);
+  });
+
+  it("quote provider can still normalize successful ZenQuotes responses when local-first is disabled", async () => {
+    const fetchImpl = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => [
+        {
+          h: "zen-42",
+          q: "  Keep\tmoving\nforward. <script> ",
+          a: "  Someone  ",
+        },
+      ],
+    });
+
+    const result = await fetchQuote({
+      preferLocal: false,
+      retries: 0,
+      timeoutMs: 100,
+      fetchImpl,
+    });
+
+    expect(result.sourceType).toBe("api");
+    expect(result.quote).toEqual({
+      id: "zen-42",
+      text: "Keep moving forward. script",
+      author: "Someone",
+      source: "ZenQuotes",
+    });
+  });
+
+  it("code generator uses exactly one snippet and preserves code casing", () => {
+    const text = codeSnippetGenerator.generateInitialText({
+      durationSeconds: 15,
+      options: {
+        includePunctuation: true,
+        includeNumbers: true,
+        randomCase: true,
+        snippet: {
+          id: "code-test",
+          language: "TypeScript",
+          source: "Example",
+          text: "const userName = formatName(input.value);",
+        },
+      },
+    });
+
+    expect(text).toBe("const userName = formatName(input.value);");
+  });
+
+  it("code provider pulls a bundled local snippet", () => {
+    const snippet = getRandomLocalCodeSnippet();
+
+    expect(snippet.text.length).toBeGreaterThan(0);
+    expect(snippet.language.length).toBeGreaterThan(0);
+    expect(snippet.source.length).toBeGreaterThan(0);
   });
 });

--- a/src/core/test/testTextGenerator.ts
+++ b/src/core/test/testTextGenerator.ts
@@ -9,6 +9,8 @@ import type {
 export type {
   AdaptiveWeakLetterGeneratorOptions,
   ClassicWordsGeneratorOptions,
+  CodeSnippetGeneratorOptions,
+  QuotesGeneratorOptions,
   TestGenerator,
   TestMode,
   TestModeConfig,

--- a/src/core/test/types.ts
+++ b/src/core/test/types.ts
@@ -1,6 +1,9 @@
 import type { WeakKeyStat } from "../storage/keyStatsStore";
 
-export type TestMode = "standard" | "adaptive";
+import type { NormalizedCodeSnippet } from "./providers/codeSnippetProvider";
+import type { NormalizedQuote } from "./providers/quoteProvider";
+
+export type TestMode = "standard" | "adaptive" | "quotes" | "code";
 
 export type ClassicWordsGeneratorOptions = {
   includePunctuation: boolean;
@@ -15,9 +18,25 @@ export type AdaptiveWeakLetterGeneratorOptions = {
   adaptiveTargets?: WeakKeyStat[];
 };
 
+export type QuotesGeneratorOptions = {
+  includePunctuation: boolean;
+  includeNumbers: boolean;
+  randomCase: boolean;
+  quote?: NormalizedQuote;
+};
+
+export type CodeSnippetGeneratorOptions = {
+  includePunctuation: boolean;
+  includeNumbers: boolean;
+  randomCase: boolean;
+  snippet?: NormalizedCodeSnippet;
+};
+
 export type TestModeOptionsMap = {
   standard: ClassicWordsGeneratorOptions;
   adaptive: AdaptiveWeakLetterGeneratorOptions;
+  quotes: QuotesGeneratorOptions;
+  code: CodeSnippetGeneratorOptions;
 };
 
 export type TestModeConfig = {

--- a/src/routes/Analytics.css
+++ b/src/routes/Analytics.css
@@ -253,10 +253,26 @@
   gap: var(--space-2);
 }
 
+.key-grid-row-wrap {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+  align-items: center;
+}
+
+.key-grid-row-label {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  color: var(--color-text-3);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
 .key-grid-row {
   display: flex;
   justify-content: center;
   gap: var(--space-2);
+  flex-wrap: wrap;
 }
 
 .key-grid-item {

--- a/src/routes/Analytics.tsx
+++ b/src/routes/Analytics.tsx
@@ -5,6 +5,8 @@ import { getAverageLatency, getKeyScore, getKeyStats } from "../core/storage/key
 import { getStreak } from "../core/storage/streakStore";
 import { sessionHistoryStore } from "../core/storage/sessionHistoryStore";
 import type { SessionReport } from "../core/session/sessionMetrics";
+import { getLocalCodeSnippets } from "../core/test/providers/codeSnippetProvider";
+import { getLocalQuotes } from "../core/test/providers/quoteProvider";
 import { PRACTICE_LESSONS } from "../core/lesson/lessons/practiceLessons";
 import { formatKeyLabel } from "../core/text/formatChar";
 import { Button } from "../ui/components/Button";
@@ -27,6 +29,14 @@ type HandFormReview = {
 
 const HAND_FORM_REVIEW_WINDOW = 20;
 const DEFAULT_TEST_DURATIONS = [15, 30, 60, 120] as const;
+const LETTER_ROWS = [
+  ["q", "w", "e", "r", "t", "y", "u", "i", "o", "p"],
+  ["a", "s", "d", "f", "g", "h", "j", "k", "l"],
+  ["z", "x", "c", "v", "b", "n", "m"],
+] as const;
+const NUMBER_ROW = "0123456789".split("");
+const PUNCTUATION_ORDER = [".", ",", ";", ":", "'", "\"", "?", "!", "-", "_"];
+const SYMBOL_ORDER = ["(", ")", "[", "]", "{", "}", "<", ">", "=", "+", "*", "/", "\\", "|", "&", "$", "#", "@", "%", "^", "`", "~"];
 
 function buildHandFormReview(reports: SessionReport[]): HandFormReview {
   const recentTests = reports
@@ -105,6 +115,58 @@ function formatCardDate(date: string | null): string {
 
 function formatStartedAt(ts: number): string {
   return new Date(ts).toLocaleString();
+}
+
+function normalizeTrackedChar(char: string): string | null {
+  if (char.trim().length === 0) return null;
+  const normalized = char.normalize("NFD").replace(/[\u0300-\u036f]/g, "");
+  return /^[A-Z]$/.test(normalized) ? normalized.toLowerCase() : normalized;
+}
+
+function collectChars(text: string, target: Set<string>): void {
+  for (const char of text) {
+    const normalized = normalizeTrackedChar(char);
+    if (normalized) {
+      target.add(normalized);
+    }
+  }
+}
+
+function buildTrackedCharacterSet(statsKeys: string[]): Set<string> {
+  const chars = new Set<string>();
+
+  LETTER_ROWS.flat().forEach((key) => chars.add(key));
+
+  getLocalQuotes().forEach((quote) => {
+    collectChars(`${quote.text} ${quote.author}`, chars);
+  });
+
+  getLocalCodeSnippets().forEach((snippet) => {
+    collectChars(snippet.text, chars);
+  });
+
+  statsKeys.forEach((key) => {
+    const normalized = normalizeTrackedChar(key);
+    if (normalized) {
+      chars.add(normalized);
+    }
+  });
+
+  return chars;
+}
+
+function orderedKnownKeys(keys: Set<string>, order: string[]): string[] {
+  return order.filter((key) => keys.has(key));
+}
+
+function orderedOtherKeys(keys: Set<string>, known: Set<string>): string[] {
+  return Array.from(keys)
+    .filter((key) => !known.has(key) && !/^[a-z0-9]$/.test(key))
+    .sort((a, b) => a.localeCompare(b));
+}
+
+function formatAnalyticsKeyLabel(key: string): string {
+  return /^[a-z]$/.test(key) ? key.toUpperCase() : formatKeyLabel(key);
 }
 
 export function Analytics({ onBack }: AnalyticsProps) {
@@ -186,8 +248,8 @@ export function Analytics({ onBack }: AnalyticsProps) {
     };
   });
 
-  const alphabetKeys = "abcdefghijklmnopqrstuvwxyz".split("");
-  const keyList = alphabetKeys.map((key) => {
+  const trackedChars = buildTrackedCharacterSet(Object.keys(keyStats));
+  const keyList = Array.from(trackedChars).map((key) => {
     const stat = keyStats[key];
     const attempts = stat?.attempts ?? 0;
     const errors = stat?.errors ?? 0;
@@ -274,7 +336,7 @@ export function Analytics({ onBack }: AnalyticsProps) {
           </div>
 
           <div className="analytics-panel">
-            <div className="analytics-panel-title">Letter Stats</div>
+            <div className="analytics-panel-title">Character Stats</div>
             <KeyGrid keys={keyList} />
           </div>
 
@@ -555,47 +617,53 @@ function KeyGrid({
 }: {
   keys: { key: string; accuracy: number; score: number; avgLatencyMs: number | null; attempts: number }[];
 }) {
+  const availableKeys = new Set(keys.map((entry) => entry.key));
+  const knownSymbols = new Set([...PUNCTUATION_ORDER, ...SYMBOL_ORDER]);
   const rows = [
-    ["q", "w", "e", "r", "t", "y", "u", "i", "o", "p"],
-    ["a", "s", "d", "f", "g", "h", "j", "k", "l"],
-    ["z", "x", "c", "v", "b", "n", "m"],
-  ] as const;
+    ...LETTER_ROWS.map((row, index) => ({ label: index === 0 ? "letters" : "", keys: [...row] })),
+    { label: "numbers", keys: orderedKnownKeys(availableKeys, NUMBER_ROW) },
+    { label: "punctuation", keys: orderedKnownKeys(availableKeys, PUNCTUATION_ORDER) },
+    { label: "symbols", keys: [...orderedKnownKeys(availableKeys, SYMBOL_ORDER), ...orderedOtherKeys(availableKeys, knownSymbols)] },
+  ].filter((row) => row.keys.length > 0);
   const keyMap = new Map(keys.map((entry) => [entry.key, entry]));
 
   return (
     <div className="key-grid">
       {rows.map((row, rowIndex) => (
-        <div key={rowIndex} className="key-grid-row">
-          {row.map((key) => {
-            const stat = keyMap.get(key) ?? {
-              key,
-              accuracy: 100,
-              score: 100,
-              avgLatencyMs: null,
-              attempts: 0,
-            };
-            const gradeClass =
-              stat.attempts === 0
-                ? "empty"
-                : stat.score < 50
-                ? "weak"
-                : stat.score >= 80
-                ? "strong"
-                : "mid";
+        <div key={rowIndex} className="key-grid-row-wrap">
+          {row.label && <div className="key-grid-row-label">{row.label}</div>}
+          <div className="key-grid-row">
+            {row.keys.map((key) => {
+              const stat = keyMap.get(key) ?? {
+                key,
+                accuracy: 100,
+                score: 100,
+                avgLatencyMs: null,
+                attempts: 0,
+              };
+              const gradeClass =
+                stat.attempts === 0
+                  ? "empty"
+                  : stat.score < 50
+                  ? "weak"
+                  : stat.score >= 80
+                  ? "strong"
+                  : "mid";
 
-            return (
-              <div
-                key={key}
-                className={`key-grid-item key-grid-item--${gradeClass}`}
-                title={`${stat.attempts} attempts · ${stat.accuracy}% accuracy${
-                  stat.avgLatencyMs != null ? ` · ${stat.avgLatencyMs}ms avg` : ""
-                }`}
-              >
-                <div className="key-grid-key">{formatKeyLabel(key).toUpperCase()}</div>
-                <div className="key-grid-acc">{stat.attempts > 0 ? `${stat.score}%` : "—"}</div>
-              </div>
-            );
-          })}
+              return (
+                <div
+                  key={key}
+                  className={`key-grid-item key-grid-item--${gradeClass}`}
+                  title={`${formatKeyLabel(key)} · ${stat.attempts} attempts · ${stat.accuracy}% accuracy${
+                    stat.avgLatencyMs != null ? ` · ${stat.avgLatencyMs}ms avg` : ""
+                  }`}
+                >
+                  <div className="key-grid-key">{formatAnalyticsKeyLabel(key)}</div>
+                  <div className="key-grid-acc">{stat.attempts > 0 ? `${stat.score}%` : "—"}</div>
+                </div>
+              );
+            })}
+          </div>
         </div>
       ))}
     </div>

--- a/src/routes/Test.css
+++ b/src/routes/Test.css
@@ -171,6 +171,22 @@
   color: var(--color-accent);
 }
 
+.test-quote-status {
+  padding: var(--space-2) var(--space-3);
+  border-radius: var(--radius-md);
+  border: 1px solid var(--color-line-2);
+  background: var(--color-surface-2);
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: var(--color-text-3);
+}
+
+.test-quote-status__reason {
+  margin-top: 4px;
+  color: var(--color-text-4, var(--color-text-3));
+  line-height: 1.4;
+}
+
 .test-setup-actions {
   display: flex;
   gap: var(--space-3);
@@ -288,6 +304,19 @@
   background: var(--color-error);
 }
 
+.test-progress-bar {
+  height: 3px;
+  background: var(--color-surface-2);
+  overflow: hidden;
+  flex-shrink: 0;
+}
+
+.test-progress-fill {
+  height: 100%;
+  background: var(--color-accent);
+  transition: width var(--transition-fast);
+}
+
 .test-idle-hint {
   font-size: 12px;
   color: var(--color-text-3);
@@ -320,6 +349,21 @@
   color: #ffd48a;
   box-shadow: 0 0 14px rgba(255, 184, 77, 0.18);
   white-space: nowrap;
+}
+
+.test-quote-source {
+  margin-left: auto;
+  font-size: 11px;
+  color: var(--color-text-3);
+  letter-spacing: 0.04em;
+}
+
+.test-quote-failure {
+  width: 100%;
+  max-width: 920px;
+  font-size: 10px;
+  color: var(--color-text-4, var(--color-text-3));
+  letter-spacing: 0.03em;
 }
 
 .test-typing-stage {

--- a/src/routes/Test.tsx
+++ b/src/routes/Test.tsx
@@ -7,10 +7,14 @@ import {
   validateTestModeConfig,
   type AdaptiveWeakLetterGeneratorOptions,
   type ClassicWordsGeneratorOptions,
+  type CodeSnippetGeneratorOptions,
+  type QuotesGeneratorOptions,
   type TestMode,
   type TestModeConfig,
   type TestModeOptionsMap,
 } from "../core/test/testTextGenerator";
+import { getRandomLocalCodeSnippet } from "../core/test/providers/codeSnippetProvider";
+import { fetchQuote, type QuoteFetchResult } from "../core/test/providers/quoteProvider";
 import { saveTestResult } from "../core/storage/testHistoryStore";
 import { updateStreak } from "../core/storage/streakStore";
 import { Keyboard, type KeyboardFingerMarker } from "../ui/components/keyboard";
@@ -26,6 +30,14 @@ import "../ui/Layout/LessonStage.css";
 import "./Test.css";
 
 type TestStatus = "setup" | "active" | "finished";
+type QuoteStatus = Pick<QuoteFetchResult, "sourceType" | "failureReason"> & {
+  author: string;
+  source: string;
+};
+type CodeStatus = {
+  language: string;
+  source: string;
+};
 
 type TestProps = {
   onBack: () => void;
@@ -61,6 +73,14 @@ const MODE_CONFIG_BUILDERS: {
       adaptiveTargets,
     },
   }),
+  quotes: (options) => ({
+    mode: "quotes",
+    options,
+  }),
+  code: (options) => ({
+    mode: "code",
+    options,
+  }),
 };
 
 export function Test({ onBack, onStatsChange, settings, initialMode = "standard" }: TestProps) {
@@ -76,6 +96,16 @@ export function Test({ onBack, onStatsChange, settings, initialMode = "standard"
       randomCase: false,
       adaptiveTargets: [],
     },
+    quotes: {
+      includePunctuation: true,
+      includeNumbers: true,
+      randomCase: false,
+    },
+    code: {
+      includePunctuation: true,
+      includeNumbers: true,
+      randomCase: false,
+    },
   });
   const [testStatus, setTestStatus] = useState<TestStatus>("setup");
   const [mode, setMode] = useState<TestMode>(initialMode);
@@ -85,6 +115,9 @@ export function Test({ onBack, onStatsChange, settings, initialMode = "standard"
   const [timeLeft, setTimeLeft] = useState(duration);
   const [timerStarted, setTimerStarted] = useState(false);
   const [textTransitioning, setTextTransitioning] = useState(false);
+  const [quoteLoading, setQuoteLoading] = useState(false);
+  const [quoteStatus, setQuoteStatus] = useState<QuoteStatus | null>(null);
+  const [codeStatus, setCodeStatus] = useState<CodeStatus | null>(null);
   const [showCamera, setShowCamera] = useState(false);
   const [restartArmed, setRestartArmed] = useState(false);
   const [capsLockOn, setCapsLockOn] = useState(false);
@@ -98,6 +131,15 @@ export function Test({ onBack, onStatsChange, settings, initialMode = "standard"
       setMode(initialMode);
     }
   }, [initialMode, testStatus]);
+
+  useEffect(() => {
+    if (testStatus === "setup" && mode === "quotes" && settings.quotesModeEnabled === false) {
+      setMode("standard");
+    }
+    if (testStatus === "setup" && mode === "code" && settings.codeModeEnabled === false) {
+      setMode("standard");
+    }
+  }, [mode, settings.codeModeEnabled, settings.quotesModeEnabled, testStatus]);
 
   const timerRef = useRef<ReturnType<typeof setInterval> | undefined>(undefined);
   const endSessionRef = useRef<() => import("../core/session/sessionTypes").SessionState | null>(null);
@@ -143,10 +185,17 @@ export function Test({ onBack, onStatsChange, settings, initialMode = "standard"
   const includePunctuation = modeOptions[mode].includePunctuation;
   const includeNumbers = modeOptions[mode].includeNumbers;
   const randomCase = modeOptions[mode].randomCase;
+  const quoteModeAvailable = settings.quotesModeEnabled !== false;
+  const codeModeAvailable = settings.codeModeEnabled !== false;
+  const isFinitePassageMode = mode === "quotes" || mode === "code";
   const handTrackingEnabled = settings.handTrackingEnabled !== false;
-  modeConfigRef.current = createModeConfig(mode);
+  if (testStatus === "setup") {
+    modeConfigRef.current = createModeConfig(mode);
+  }
 
   const maybeRefill = useCallback((typedLength: number) => {
+    if (modeConfigRef.current.mode === "quotes" || modeConfigRef.current.mode === "code") return;
+
     const remaining = textLengthRef.current - typedLength;
 
     if (remaining >= BUFFER_AHEAD_CHARS || refillingRef.current) return;
@@ -165,13 +214,31 @@ export function Test({ onBack, onStatsChange, settings, initialMode = "standard"
     }, 0);
   }, []);
 
+  const handleFiniteModeComplete = useCallback((stats: import("../hooks/useTyping").TypingStats) => {
+    if (hasEndedRef.current) return;
+
+    hasEndedRef.current = true;
+    saveTestResult({
+      wpm: stats.wpm,
+      rawWpm: stats.rawWpm,
+      accuracy: stats.accuracy,
+      errors: stats.errors,
+      chars: stats.chars,
+      elapsed: stats.elapsed,
+      date: new Date().toISOString(),
+      completed: true,
+    });
+    updateStreak();
+    onStatsChange?.();
+    setTestStatus("finished");
+  }, [onStatsChange]);
+
   const typing = useTypingSession({
     text,
     enabled: testStatus === "active",
     sessionType: "test",
-    // Timer is the ONLY thing that ends a timed test.
-    // Text exhaustion is prevented by the dynamic refill above.
-    onComplete: undefined,
+    // Timed modes are ended by the countdown. Quotes/code modes are finite passages.
+    onComplete: isFinitePassageMode ? handleFiniteModeComplete : undefined,
     onProgress: ({ typedLength }) => {
       maybeRefill(typedLength);
     },
@@ -200,15 +267,59 @@ export function Test({ onBack, onStatsChange, settings, initialMode = "standard"
     typingRef.current?.reset();
   }, [duration]);
 
+  const withPreparedQuote = useCallback(async (config: TestModeConfig): Promise<TestModeConfig> => {
+    if (config.mode !== "quotes") return config;
+
+    setQuoteLoading(true);
+
+    try {
+      const result = await fetchQuote({ timeoutMs: 900, retries: 0 });
+      setQuoteStatus({
+        author: result.quote.author,
+        source: result.quote.source,
+        sourceType: result.sourceType,
+        failureReason: result.failureReason,
+      });
+
+      return {
+        mode: "quotes",
+        options: {
+          ...config.options,
+          quote: result.quote,
+        },
+      };
+    } finally {
+      setQuoteLoading(false);
+    }
+  }, []);
+
+  const withPreparedCodeSnippet = useCallback((config: TestModeConfig): TestModeConfig => {
+    if (config.mode !== "code") return config;
+
+    const snippet = getRandomLocalCodeSnippet();
+    setCodeStatus({
+      language: snippet.language,
+      source: snippet.source,
+    });
+
+    return {
+      mode: "code",
+      options: {
+        ...config.options,
+        snippet,
+      },
+    };
+  }, []);
+
   /* Regenerate during active test — used by settings change and manual new test */
-  const regenerateTest = useCallback(() => {
+  const regenerateTest = useCallback((config: TestModeConfig = modeConfigRef.current) => {
     if (testStatus !== "active") return undefined;
 
     setTextTransitioning(true);
     clearInterval(timerRef.current);
 
     const timeout = setTimeout(() => {
-      generateAndLoadTest();
+      generateAndLoadTest(config);
       setTextTransitioning(false);
     }, TRANSITION_MS);
 
@@ -233,8 +344,12 @@ export function Test({ onBack, onStatsChange, settings, initialMode = "standard"
       randomCase,
     };
     if (changed) {
-      modeConfigRef.current = createModeConfig(mode);
-      const cleanup = regenerateTest();
+      const activeConfig =
+        isFinitePassageMode && modeConfigRef.current.mode === mode
+          ? modeConfigRef.current
+          : createModeConfig(mode);
+      modeConfigRef.current = activeConfig;
+      const cleanup = regenerateTest(activeConfig);
       return cleanup;
     }
   }, [testStatus, text, duration, mode, includePunctuation, includeNumbers, randomCase, createModeConfig, regenerateTest]);
@@ -323,7 +438,7 @@ export function Test({ onBack, onStatsChange, settings, initialMode = "standard"
 
   /* Countdown — 100ms interval against a fixed start timestamp, not integer decrement */
   useEffect(() => {
-    if (testStatus !== "active") return;
+    if (testStatus !== "active" || isFinitePassageMode) return;
     const interval = setInterval(() => {
       if (!startRef.current) return;
       if (pauseStartedAtRef.current) return;
@@ -353,14 +468,15 @@ export function Test({ onBack, onStatsChange, settings, initialMode = "standard"
       }
     }, 100);
     return () => clearInterval(interval);
-  }, [testStatus, duration, onStatsChange]);
+  }, [testStatus, duration, isFinitePassageMode, onStatsChange]);
 
-  const startTest = useCallback(() => {
+  const startTest = useCallback(async () => {
     hasEndedRef.current = false;
     const nextAdaptiveTargets = mode === "adaptive" ? getWeakLetterTargets(5) : [];
     adaptiveTargetsRef.current = nextAdaptiveTargets;
     const nextConfig = createModeConfig(mode, nextAdaptiveTargets);
-    const validatedConfig = validateModeConfig(nextConfig);
+    const preparedConfig = withPreparedCodeSnippet(await withPreparedQuote(nextConfig));
+    const validatedConfig = validateModeConfig(preparedConfig);
     if (!validatedConfig) return;
     modeConfigRef.current = validatedConfig;
     prevSettingsRef.current = {
@@ -372,7 +488,7 @@ export function Test({ onBack, onStatsChange, settings, initialMode = "standard"
     };
     generateAndLoadTest(validatedConfig);
     setTestStatus("active");
-  }, [createModeConfig, duration, generateAndLoadTest, mode, validateModeConfig]);
+  }, [createModeConfig, duration, generateAndLoadTest, mode, validateModeConfig, withPreparedCodeSnippet, withPreparedQuote]);
 
   const backToSetup = useCallback(() => {
     clearInterval(timerRef.current);
@@ -384,16 +500,17 @@ export function Test({ onBack, onStatsChange, settings, initialMode = "standard"
     typingRef.current?.reset();
   }, []);
 
-  const handleNewTest = useCallback(() => {
+  const handleNewTest = useCallback(async () => {
     if (testStatus !== "active") return;
     const nextAdaptiveTargets = mode === "adaptive" ? getWeakLetterTargets(5) : [];
     adaptiveTargetsRef.current = nextAdaptiveTargets;
     const nextConfig = createModeConfig(mode, nextAdaptiveTargets);
-    const validatedConfig = validateModeConfig(nextConfig);
+    const preparedConfig = withPreparedCodeSnippet(await withPreparedQuote(nextConfig));
+    const validatedConfig = validateModeConfig(preparedConfig);
     if (!validatedConfig) return;
     modeConfigRef.current = validatedConfig;
-    regenerateTest();
-  }, [createModeConfig, mode, testStatus, regenerateTest, validateModeConfig]);
+    regenerateTest(validatedConfig);
+  }, [createModeConfig, mode, testStatus, regenerateTest, validateModeConfig, withPreparedCodeSnippet, withPreparedQuote]);
 
   const clearRestartArm = useCallback(() => {
     if (pauseStartedAtRef.current) {
@@ -410,17 +527,18 @@ export function Test({ onBack, onStatsChange, settings, initialMode = "standard"
     setRestartArmed(true);
   }, [timerStarted]);
 
-  const retryWithSameSettings = useCallback(() => {
+  const retryWithSameSettings = useCallback(async () => {
     hasEndedRef.current = false;
     const nextAdaptiveTargets = mode === "adaptive" ? getWeakLetterTargets(5) : [];
     adaptiveTargetsRef.current = nextAdaptiveTargets;
     const nextConfig = createModeConfig(mode, nextAdaptiveTargets);
-    const validatedConfig = validateModeConfig(nextConfig);
+    const preparedConfig = withPreparedCodeSnippet(await withPreparedQuote(nextConfig));
+    const validatedConfig = validateModeConfig(preparedConfig);
     if (!validatedConfig) return;
     modeConfigRef.current = validatedConfig;
     generateAndLoadTest(validatedConfig);
     setTestStatus("active");
-  }, [createModeConfig, generateAndLoadTest, mode, validateModeConfig]);
+  }, [createModeConfig, generateAndLoadTest, mode, validateModeConfig, withPreparedCodeSnippet, withPreparedQuote]);
 
   const cycleDuration = useCallback(() => {
     const idx = DURATION_OPTIONS.indexOf(duration as (typeof DURATION_OPTIONS)[number]);
@@ -431,8 +549,8 @@ export function Test({ onBack, onStatsChange, settings, initialMode = "standard"
   const updateCurrentWordOptions = useCallback(
     (
       updater: (
-        current: ClassicWordsGeneratorOptions | AdaptiveWeakLetterGeneratorOptions
-      ) => ClassicWordsGeneratorOptions | AdaptiveWeakLetterGeneratorOptions
+        current: ClassicWordsGeneratorOptions | AdaptiveWeakLetterGeneratorOptions | QuotesGeneratorOptions | CodeSnippetGeneratorOptions
+      ) => ClassicWordsGeneratorOptions | AdaptiveWeakLetterGeneratorOptions | QuotesGeneratorOptions | CodeSnippetGeneratorOptions
     ) => {
       setModeOptions((current) => ({
         ...current,
@@ -535,7 +653,9 @@ export function Test({ onBack, onStatsChange, settings, initialMode = "standard"
       <div className="test-results-page">
         <SessionReportCard
           report={typing.report}
-          onRetry={retryWithSameSettings}
+          onRetry={() => {
+            void retryWithSameSettings();
+          }}
           onHome={onBack}
         />
         <div className="test-results-extra-actions">
@@ -575,76 +695,110 @@ export function Test({ onBack, onStatsChange, settings, initialMode = "standard"
               >
                 <span className="test-setup-mode-card__title">Adaptive</span>
                 <span className="test-setup-mode-card__body">
-                  Prioritizes weaker letters when there is enough history.
+                  Prioritizes weaker letters.
                 </span>
               </button>
-            </div>
-          </div>
-
-          <div className="test-setup-section">
-            <div className="test-setup-label">Duration</div>
-            <div className="test-setup-duration">
-              {DURATION_OPTIONS.map((d) => (
+              {quoteModeAvailable && (
                 <button
-                  key={d}
                   type="button"
-                  className={`test-setup-duration-btn ${duration === d ? "active" : ""}`}
-                  onClick={() => setDuration(d)}
+                  className={`test-setup-mode-card ${mode === "quotes" ? "active" : ""}`}
+                  onClick={() => setMode("quotes")}
                 >
-                  {d}s
+                  <span className="test-setup-mode-card__title">Quotes</span>
+                  <span className="test-setup-mode-card__body">
+                    Quotes from famous people and books.
+                  </span>
                 </button>
-              ))}
+              )}
+              {codeModeAvailable && (
+                <button
+                  type="button"
+                  className={`test-setup-mode-card ${mode === "code" ? "active" : ""}`}
+                  onClick={() => setMode("code")}
+                >
+                  <span className="test-setup-mode-card__title">Code</span>
+                  <span className="test-setup-mode-card__body">
+                    Popular algorithms across different languages.
+                  </span>
+                </button>
+              )}
             </div>
           </div>
 
-          <div className="test-setup-section">
-            <div className="test-setup-label">Include</div>
-            <div className="test-setup-toggles">
-              <button
-                type="button"
-                className={`test-setup-toggle ${includePunctuation ? "active" : ""}`}
-                onClick={() =>
-                  updateCurrentWordOptions((current) => ({
-                    ...current,
-                    includePunctuation: !current.includePunctuation,
-                  }))
-                }
-              >
-                Punctuation
-              </button>
-              <button
-                type="button"
-                className={`test-setup-toggle ${includeNumbers ? "active" : ""}`}
-                onClick={() =>
-                  updateCurrentWordOptions((current) => ({
-                    ...current,
-                    includeNumbers: !current.includeNumbers,
-                  }))
-                }
-              >
-                Numbers
-              </button>
-              <button
-                type="button"
-                className={`test-setup-toggle ${randomCase ? "active" : ""}`}
-                onClick={() =>
-                  updateCurrentWordOptions((current) => ({
-                    ...current,
-                    randomCase: !current.randomCase,
-                  }))
-                }
-              >
-                Random Case
-              </button>
+          {!isFinitePassageMode && (
+            <div className="test-setup-section">
+              <div className="test-setup-label">Duration</div>
+              <div className="test-setup-duration">
+                {DURATION_OPTIONS.map((d) => (
+                  <button
+                    key={d}
+                    type="button"
+                    className={`test-setup-duration-btn ${duration === d ? "active" : ""}`}
+                    onClick={() => setDuration(d)}
+                  >
+                    {d}s
+                  </button>
+                ))}
+              </div>
             </div>
-          </div>
+          )}
+
+          {!isFinitePassageMode && (
+            <div className="test-setup-section">
+              <div className="test-setup-label">Include</div>
+              <div className="test-setup-toggles">
+                <button
+                  type="button"
+                  className={`test-setup-toggle ${includePunctuation ? "active" : ""}`}
+                  onClick={() =>
+                    updateCurrentWordOptions((current) => ({
+                      ...current,
+                      includePunctuation: !current.includePunctuation,
+                    }))
+                  }
+                >
+                  Punctuation
+                </button>
+                <button
+                  type="button"
+                  className={`test-setup-toggle ${includeNumbers ? "active" : ""}`}
+                  onClick={() =>
+                    updateCurrentWordOptions((current) => ({
+                      ...current,
+                      includeNumbers: !current.includeNumbers,
+                    }))
+                  }
+                >
+                  Numbers
+                </button>
+                <button
+                  type="button"
+                  className={`test-setup-toggle ${randomCase ? "active" : ""}`}
+                  onClick={() =>
+                    updateCurrentWordOptions((current) => ({
+                      ...current,
+                      randomCase: !current.randomCase,
+                    }))
+                  }
+                >
+                  Random Case
+                </button>
+              </div>
+            </div>
+          )}
 
           <div className="test-setup-actions">
             <Button variant="secondary" onClick={onBack}>
               Back
             </Button>
-            <Button variant="primary" onClick={startTest}>
-              Start Test
+            <Button
+              variant="primary"
+              disabled={quoteLoading}
+              onClick={() => {
+                void startTest();
+              }}
+            >
+              {quoteLoading ? "Loading..." : "Start Test"}
             </Button>
           </div>
         </div>
@@ -671,54 +825,62 @@ export function Test({ onBack, onStatsChange, settings, initialMode = "standard"
           <div className={`test-topbar-badge ${mode === "adaptive" ? "on" : "off"}`}>
             {mode}
           </div>
-          <button
-            type="button"
-            className="test-topbar-duration-btn"
-            onClick={cycleDuration}
-            title="Change duration"
-          >
-            {duration}s
-          </button>
-          <button
-            type="button"
-            className={`test-topbar-badge ${includePunctuation ? "on" : "off"}`}
-            onClick={() =>
-              updateCurrentWordOptions((current) => ({
-                ...current,
-                includePunctuation: !current.includePunctuation,
-              }))
-            }
-          >
-            punct
-          </button>
-          <button
-            type="button"
-            className={`test-topbar-badge ${includeNumbers ? "on" : "off"}`}
-            onClick={() =>
-              updateCurrentWordOptions((current) => ({
-                ...current,
-                includeNumbers: !current.includeNumbers,
-              }))
-            }
-          >
-            nums
-          </button>
-          <button
-            type="button"
-            className={`test-topbar-badge ${randomCase ? "on" : "off"}`}
-            onClick={() =>
-              updateCurrentWordOptions((current) => ({
-                ...current,
-                randomCase: !current.randomCase,
-              }))
-            }
-          >
-            case
-          </button>
+          {!isFinitePassageMode && (
+            <button
+              type="button"
+              className="test-topbar-duration-btn"
+              onClick={cycleDuration}
+              title="Change duration"
+            >
+              {duration}s
+            </button>
+          )}
+          {!isFinitePassageMode && (
+            <>
+              <button
+                type="button"
+                className={`test-topbar-badge ${includePunctuation ? "on" : "off"}`}
+                onClick={() =>
+                  updateCurrentWordOptions((current) => ({
+                    ...current,
+                    includePunctuation: !current.includePunctuation,
+                  }))
+                }
+              >
+                punct
+              </button>
+              <button
+                type="button"
+                className={`test-topbar-badge ${includeNumbers ? "on" : "off"}`}
+                onClick={() =>
+                  updateCurrentWordOptions((current) => ({
+                    ...current,
+                    includeNumbers: !current.includeNumbers,
+                  }))
+                }
+              >
+                nums
+              </button>
+              <button
+                type="button"
+                className={`test-topbar-badge ${randomCase ? "on" : "off"}`}
+                onClick={() =>
+                  updateCurrentWordOptions((current) => ({
+                    ...current,
+                    randomCase: !current.randomCase,
+                  }))
+                }
+              >
+                case
+              </button>
+            </>
+          )}
           <button
             type="button"
             className="test-topbar-new-btn"
-            onClick={handleNewTest}
+            onClick={() => {
+              void handleNewTest();
+            }}
             title="New test"
           >
             new
@@ -734,19 +896,32 @@ export function Test({ onBack, onStatsChange, settings, initialMode = "standard"
             </button>
           )}
         </div>
-        <div className={`test-topbar-timer test-topbar-timer--${timerClass}`}>
-          {timerStarted ? timeLeft : duration}s
-        </div>
+        {!isFinitePassageMode && (
+          <div className={`test-topbar-timer test-topbar-timer--${timerClass}`}>
+            {timerStarted ? timeLeft : duration}s
+          </div>
+        )}
       </div>
 
-      <div className="test-timer-bar">
-        <div
-          className={`test-timer-fill test-timer-fill--${timerClass}`}
-          style={{
-            width: `${(timerStarted ? timeLeft : duration) / duration * 100}%`,
-          }}
-        />
-      </div>
+      {isFinitePassageMode ? (
+        <div className="test-progress-bar">
+          <div
+            className="test-progress-fill"
+            style={{
+              width: `${Math.min(100, Math.max(0, typing.progress * 100))}%`,
+            }}
+          />
+        </div>
+      ) : (
+        <div className="test-timer-bar">
+          <div
+            className={`test-timer-fill test-timer-fill--${timerClass}`}
+            style={{
+              width: `${(timerStarted ? timeLeft : duration) / duration * 100}%`,
+            }}
+          />
+        </div>
+      )}
 
       <div className="lesson-stage-body" onClick={handleTypingAreaClick}>
         <input
@@ -765,10 +940,33 @@ export function Test({ onBack, onStatsChange, settings, initialMode = "standard"
               </div>
             )}
             {capsLockOn && <div className="test-caps-indicator mono-label">Caps Lock on</div>}
+            {mode === "quotes" && quoteStatus && (
+              <div
+                className="test-quote-source mono-label"
+                title={quoteStatus.failureReason ?? `${quoteStatus.sourceType} · ${quoteStatus.source}`}
+              >
+                {quoteStatus.author} · {quoteStatus.source}
+              </div>
+            )}
+            {mode === "code" && codeStatus && (
+              <div
+                className="test-quote-source mono-label"
+                title={codeStatus.source}
+              >
+                {codeStatus.language} · {codeStatus.source}
+              </div>
+            )}
           </div>
           {!timerStarted && (
             <div className="test-idle-hint mono-label">
-              Start typing — timer begins on first keypress
+              {isFinitePassageMode
+                ? `Start typing to begin the ${mode === "code" ? "snippet" : "quote"}`
+                : "Start typing — timer begins on first keypress"}
+            </div>
+          )}
+          {mode === "quotes" && quoteStatus?.failureReason && (
+            <div className="test-quote-failure mono-label">
+              {quoteStatus.failureReason}
             </div>
           )}
 

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />


### PR DESCRIPTION
This pull request introduces two new test modes—quotes and code snippets—by adding support for generating typing tests from curated quote passages and code snippets. It also includes robust local and remote quote/code providers, new configuration options, and comprehensive tests for these features. Additionally, there are improvements to key statistics normalization and settings management.

The most important changes are:

**New Test Modes and Generators**
- Added `quotesGenerator` and `codeSnippetGenerator` as new test generators, and registered them in the test mode registry (`src/core/test/quotesGenerator.ts`, `src/core/test/codeSnippetGenerator.ts`, `src/core/test/registry.ts`, [[1]](diffhunk://#diff-179464667c75515e9b149d476c7d752563441bb7794e715a437cbf60fb1df34cR1-R50) [[2]](diffhunk://#diff-266d2e61eec7ac2ad584def265a314dd83c0a135aa5d5f8db8b2e304dd6282e0R1-R46) [[3]](diffhunk://#diff-5e2b7ef1e3dbf02a9cc5e9e07057acbeffd5755f655572459f94746b0a1dbbbcR3-R13).
- Created associated provider modules for quotes and code snippets, supporting loading and parsing of local passages/snippets and fetching quotes from remote APIs (`src/core/test/providers/quoteProvider.ts`, `src/core/test/providers/codeSnippetProvider.ts`, [[1]](diffhunk://#diff-3cef1c5dbbc97b413f761e0492549a7658adc520f2606a564ac732ef99323e83R1-R261) [[2]](diffhunk://#diff-5c1503063834f3cba24424da4f20c07084c816fcb52dbc3e639895481db21dc7R1-R56).

**Settings and Configuration**
- Added new settings flags `quotesModeEnabled` and `codeModeEnabled` (defaulting to true) in the `Settings` type and defaults, allowing these modes to be toggled (`src/core/storage/settingsStore.ts`, [[1]](diffhunk://#diff-c035fd6217e6b0673a8ec6503d0800350142859726e1425411ad409b42a11312R8-R9) [[2]](diffhunk://#diff-c035fd6217e6b0673a8ec6503d0800350142859726e1425411ad409b42a11312R51-R52).

**Key Statistics Normalization**
- Improved normalization of tracked keys in key statistics to be case-insensitive and accent-insensitive, and merged stats for equivalent keys (`src/core/storage/keyStatsStore.ts`, [[1]](diffhunk://#diff-4dec7b60b458e8a79abaece81252ea2f33851df5847ab17b68c3c150b1ef88c3R61-R67) [[2]](diffhunk://#diff-4dec7b60b458e8a79abaece81252ea2f33851df5847ab17b68c3c150b1ef88c3R132-R163).

**Testing**
- Added comprehensive tests for the new generators and providers, verifying that quote/code text is correctly formatted, casing is preserved, local/remote fallback works, and the registry includes the new modes (`src/core/test/testGenerators.test.ts`, [[1]](diffhunk://#diff-03e30b0a6af066f648d2d60753297e4a12b33a94057e43a563ee6439e85aa538R4-R9) [[2]](diffhunk://#diff-03e30b0a6af066f648d2d60753297e4a12b33a94057e43a563ee6439e85aa538R125-R233).
- Updated type exports to include new generator option types (`src/core/test/testTextGenerator.ts`, [src/core/test/testTextGenerator.tsR12-R13](diffhunk://#diff-538f00d7702039bf402204754ff635053db7a2a9d1b9dac2098b90716fd5b42eR12-R13)).

**Developer Tooling**
- Added a script (`scripts/import-passages.mjs`) for importing and normalizing passages from various formats into the local passages file used by the quote provider.